### PR TITLE
moved LDFLAGS to end of gcc invocation to fix build

### DIFF
--- a/makefiles/makefile.unix.6502
+++ b/makefiles/makefile.unix.6502
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6502 ; strip wla-6502
+	$(LD) $(OFILES) -o wla-6502 $(LDFLAGS) ; strip wla-6502
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.6510
+++ b/makefiles/makefile.unix.6510
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6510 ; strip wla-6510
+	$(LD) $(OFILES) -o wla-6510 $(LDFLAGS) ; strip wla-6510
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.65816
+++ b/makefiles/makefile.unix.65816
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65816 ; strip wla-65816
+	$(LD) $(OFILES) -o wla-65816 $(LDFLAGS) ; strip wla-65816
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.65c02
+++ b/makefiles/makefile.unix.65c02
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65c02 ; strip wla-65c02
+	$(LD) $(OFILES) -o wla-65c02 $(LDFLAGS) ; strip wla-65c02
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.gb
+++ b/makefiles/makefile.unix.gb
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-gb ; strip wla-gb
+	$(LD) $(OFILES) -o wla-gb $(LDFLAGS) ; strip wla-gb
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.huc6280
+++ b/makefiles/makefile.unix.huc6280
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-huc6280 ; strip wla-huc6280
+	$(LD) $(OFILES) -o wla-huc6280 $(LDFLAGS); strip wla-huc6280
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.spc700
+++ b/makefiles/makefile.unix.spc700
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-spc700 ; strip wla-spc700
+	$(LD) $(OFILES) -o wla-spc700 $(LDFLAGS) ; strip wla-spc700
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c

--- a/makefiles/makefile.unix.z80
+++ b/makefiles/makefile.unix.z80
@@ -12,7 +12,7 @@ OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack
 
 
 all: $(OFILES) 
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-z80 ; strip wla-z80
+	$(LD) $(OFILES) -o wla-z80 $(LDFLAGS) ; strip wla-z80
 
 main.o: main.c defines.h main.h 
 	$(CC) $(WLAFLAGS) main.c


### PR DESCRIPTION
Hi! I noticed that things weren't linking under Ubuntu 14.10, with the following error:

```
gcc -lm main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o -o wla-huc6280 ; strip wla-huc6280
pass_1.o: In function `parse_directive':
pass_1.c:(.text+0x9af5): undefined reference to `cos'
pass_1.c:(.text+0xa710): undefined reference to `sin'
collect2: error: ld returned 1 exit status
```

Apparently you have to put the -lm flag to gcc at the end, or the math libs won't be correctly linked. This patch adjusts the unix.\* makefiles to move LDFLAGS and make everything build. I don't know if this fix is necessary on the other platforms, since I don't have them available for testing.
