### PR TITLE
Added CMake build system for convenient native windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Main CMakeLists file
+cmake_minimum_required (VERSION 2.8.9)
+
+# --- Project name ---
+project (WLA-DX)
+
+# --- Explicitly enable C
+enable_language (C)
+
+# --- GCC flags 
+if (CMAKE_COMPILER_IS_GNUCC)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -ansi -pedantic-errors -Wall -Wextra -lm")
+endif (CMAKE_COMPILER_IS_GNUCC)
+
+# --- Tell MSVC to STFU about _CRT_SECURE_NO_WARNINGS
+if (MSVC)
+    add_definitions( -D_CRT_SECURE_NO_WARNINGS )
+endif (MSVC)
+
+#Make the source tree available to includes
+include_directories(${PROJECT_SOURCE_DIR})
+#Generated tables are created at the top build-tree directory
+include_directories(${CMAKE_BINARY_DIR})
+
+# --- Dependencies ---
+add_subdirectory (opcode_table_generator)
+add_subdirectory (wlab)
+add_subdirectory (wlalink)
+
+# --- WLA executables ---
+set(CFILES main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c)
+
+#GB
+add_executable(wla-gb ${CFILES})
+set_target_properties (wla-gb PROPERTIES COMPILE_DEFINITIONS "GB" )
+add_dependencies(wla-gb GB_table)
+
+#WDC65C02
+add_executable(wla-65c02 ${CFILES})
+set_target_properties (wla-65c02 PROPERTIES COMPILE_DEFINITIONS "WDC65C02" )
+add_dependencies(wla-65c02 WDC65C02_table)
+
+#MCS6502
+add_executable(wla-6502 ${CFILES})
+set_target_properties (wla-6502 PROPERTIES COMPILE_DEFINITIONS "MCS6502" )
+add_dependencies(wla-6502 MCS6502_table)
+
+#MCS6510
+add_executable(wla-6510 ${CFILES})
+set_target_properties (wla-6510 PROPERTIES COMPILE_DEFINITIONS "MCS6510" )
+add_dependencies(wla-6510 MCS6510_table)
+
+#W65816
+add_executable(wla-65816 ${CFILES})
+set_target_properties (wla-65816 PROPERTIES COMPILE_DEFINITIONS "W65816" )
+add_dependencies(wla-65816 W65816_table)
+
+#HUC6280
+add_executable(wla-huc6280 ${CFILES})
+set_target_properties (wla-huc6280 PROPERTIES COMPILE_DEFINITIONS "HUC6280" )
+add_dependencies(wla-huc6280 HUC6280_table)
+
+#SPC700
+add_executable(wla-spc700 ${CFILES})
+set_target_properties (wla-spc700 PROPERTIES COMPILE_DEFINITIONS "SPC700" )
+add_dependencies(wla-spc700 SPC700_table)
+
+#Z80
+add_executable(wla-z80 ${CFILES})
+set_target_properties (wla-z80 PROPERTIES COMPILE_DEFINITIONS "Z80" )
+add_dependencies(wla-z80 Z80_table)
+
+

--- a/opcode_table_generator/CMakeLists.txt
+++ b/opcode_table_generator/CMakeLists.txt
@@ -1,0 +1,94 @@
+# Subproject: opcode_table_generator
+project(opcode_table_generator)
+
+#add_definitions( -DWLA_QUIET )
+set(CFILES main.c)
+
+# --- WLA_TARGET=GB
+add_executable (gen_GB ${CFILES})
+set_target_properties (gen_GB PROPERTIES COMPILE_DEFINITIONS "GB")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_gb_tables.c
+	COMMAND gen_GB
+	DEPENDS gen_GB
+	)
+ADD_CUSTOM_TARGET(GB_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_gb_tables.c)
+
+# --- WLA_TARGET=Z80
+add_executable (gen_Z80 ${CFILES})
+set_target_properties (gen_Z80 PROPERTIES COMPILE_DEFINITIONS "Z80")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_z80_tables.c
+	COMMAND gen_Z80
+	DEPENDS gen_Z80
+	)
+ADD_CUSTOM_TARGET(Z80_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_z80_tables.c)
+
+# --- WLA_TARGET=MCS6502
+add_executable (gen_MCS6502 ${CFILES})
+set_target_properties (gen_MCS6502 PROPERTIES COMPILE_DEFINITIONS "MCS6502")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_6502_tables.c
+	COMMAND gen_MCS6502
+	DEPENDS gen_MCS6502
+	)
+ADD_CUSTOM_TARGET(MCS6502_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_6502_tables.c)
+
+# --- WLA_TARGET=WDC65C02
+add_executable (gen_WDC65C02 ${CFILES})
+set_target_properties (gen_WDC65C02 PROPERTIES COMPILE_DEFINITIONS "WDC65C02")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_65c02_tables.c
+	COMMAND gen_WDC65C02
+	DEPENDS gen_WDC65C02
+	)
+ADD_CUSTOM_TARGET(WDC65C02_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_65c02_tables.c)
+
+# --- WLA_TARGET=MCS6510
+add_executable (gen_MCS6510 ${CFILES})
+set_target_properties (gen_MCS6510 PROPERTIES COMPILE_DEFINITIONS "MCS6510")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_6510_tables.c
+	COMMAND gen_MCS6510
+	DEPENDS gen_MCS6510
+	)
+ADD_CUSTOM_TARGET(MCS6510_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_6510_tables.c)
+
+# --- WLA_TARGET=W65816
+add_executable (gen_W65816 ${CFILES})
+set_target_properties (gen_W65816 PROPERTIES COMPILE_DEFINITIONS "W65816")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_65816_tables.c
+	COMMAND gen_W65816
+	DEPENDS gen_W65816
+	)
+ADD_CUSTOM_TARGET(W65816_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_65816_tables.c)
+
+# --- WLA_TARGET=SPC700
+add_executable (gen_SPC700 ${CFILES})
+set_target_properties (gen_SPC700 PROPERTIES COMPILE_DEFINITIONS "SPC700")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_spc700_tables.c
+	COMMAND gen_SPC700
+	DEPENDS gen_SPC700
+	)
+ADD_CUSTOM_TARGET(SPC700_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_spc700_tables.c)
+
+# --- WLA_TARGET=HUC6280
+add_executable (gen_HUC6280 ${CFILES})
+set_target_properties (gen_HUC6280 PROPERTIES COMPILE_DEFINITIONS "HUC6280")
+#Generate tables
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/opcodes_huc6280_tables.c
+	COMMAND gen_HUC6280
+	DEPENDS gen_HUC6280
+	)
+ADD_CUSTOM_TARGET(HUC6280_table ALL DEPENDS ${CMAKE_BINARY_DIR}/opcodes_huc6280_tables.c)
+

--- a/wlab/CMakeLists.txt
+++ b/wlab/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Subproject: wlab
+project(wlab)
+
+set(CFILES main.c)
+add_executable(wlab ${CFILES})
+

--- a/wlalink/CMakeLists.txt
+++ b/wlalink/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Subproject: wlalink
+project(wlalink)
+
+set(CFILES main.c memory.c parse.c files.c check.c analyze.c write.c compute.c discard.c listfile.c)
+add_executable(wlalink ${CFILES})
+


### PR DESCRIPTION
I wanted to compile WLA under windows without setting up mysys or make so I ported the build system to CMake. While the main target is creating native binaries under windows, cmake can be used to build WLA under linux too.

Both build systems can coexist since the only change to the source tree are the newly created CMakeLists.txt files.