### PR TITLE
pass_1.c: rename variable, 'asm' is reserved keyword with clang

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -6452,7 +6452,7 @@ int parse_directive(void) {
 
   if (strcmp(cp, "ENDASM") == 0) {
 
-    int asm = 1, x;
+    int endasm = 1, x;
 
 
     while (1) {
@@ -6467,12 +6467,12 @@ int parse_directive(void) {
         return SUCCEEDED;
       }
       if (strcaselesscmp(tmp, ".ASM") == 0) {
-        asm--;
-        if (asm == 0)
+        endasm--;
+        if (endasm == 0)
           return SUCCEEDED;
       }
       if (strcaselesscmp(tmp, ".ENDASM") == 0)
-        asm++;
+        endasm++;
     }
   }
 


### PR DESCRIPTION
Minor fix to make the cmake build pass on OSX (using system clang);

without the patch I got this output:

```
/Users/m/dev/wla-dx/pass_1.c:6455:9: error: expected identifier or '('
    int asm = 1, x;
        ^
/Users/m/dev/wla-dx/pass_1.c:6459:7: error: use of undeclared identifier 'x'
      x = i;
      ^
/Users/m/dev/wla-dx/pass_1.c:6466:13: error: use of undeclared identifier 'x'
        i = x;
            ^
/Users/m/dev/wla-dx/pass_1.c:6470:12: error: expected '(' after 'asm'
        asm--;
           ^
/Users/m/dev/wla-dx/pass_1.c:6471:13: error: expected expression
        if (asm == 0)
            ^
/Users/m/dev/wla-dx/pass_1.c:6475:12: error: expected '(' after 'asm'
        asm++;
           ^
```