### PR TITLE
strcaselesscmp

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -1083,7 +1083,7 @@ int parse_directive(void) {
   
   /* ORG */
 
-  if (strcmp(cp, "ORG") == 0) {
+  if (strcaselesscmp(cp, "ORG") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ORG definitions.\n", ERROR_DIR);
       return FAILED;
@@ -1114,7 +1114,7 @@ int parse_directive(void) {
 
   /* ORGA */
 
-  if (strcmp(cp, "ORGA") == 0) {
+  if (strcaselesscmp(cp, "ORGA") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ORGA definitions.\n", ERROR_DIR);
       return FAILED;
@@ -1153,7 +1153,7 @@ int parse_directive(void) {
 
   /* SLOT */
 
-  if (strcmp(cp, "SLOT") == 0) {
+  if (strcaselesscmp(cp, "SLOT") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .SLOT definitions.\n", ERROR_DIR);
       return FAILED;
@@ -1188,7 +1188,7 @@ int parse_directive(void) {
 
   /* BANK */
 
-  if (strcmp(cp, "BANK") == 0) {
+  if (strcaselesscmp(cp, "BANK") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .BANK definitions.\n", ERROR_DIR);
       return FAILED;
@@ -1268,7 +1268,7 @@ int parse_directive(void) {
 
   /* DBM/DWM? */
 
-  if (strcmp(cp, "DBM") == 0 || strcmp(cp, "DWM") == 0) {
+  if (strcaselesscmp(cp, "DBM") == 0 || strcaselesscmp(cp, "DWM") == 0) {
 
     struct macro_static *m;
 
@@ -1289,7 +1289,7 @@ int parse_directive(void) {
       return FAILED;
     }
 
-    if (strcmp(cp, "DBM") == 0) {
+    if (strcaselesscmp(cp, "DBM") == 0) {
       if (macro_start_dxm(m, MACRO_CALLER_DBM, cp, YES) == FAILED)
         return FAILED;
     }
@@ -1303,7 +1303,7 @@ int parse_directive(void) {
 
   /* DB/BYT/BYTE? */
 
-  if (strcmp(cp, "DB") == 0 || strcmp(cp, "BYT") == 0 || strcmp(cp, "BYTE") == 0) {
+  if (strcaselesscmp(cp, "DB") == 0 || strcaselesscmp(cp, "BYT") == 0 || strcaselesscmp(cp, "BYTE") == 0) {
     strcpy(bak, cp);
 
     inz = input_number();
@@ -1348,7 +1348,7 @@ int parse_directive(void) {
 
   /* ASCTABLE/ASCIITABLE? */
 
-  if (strcmp(cp, "ASCTABLE") == 0 || strcmp(cp, "ASCIITABLE") == 0) {
+  if (strcaselesscmp(cp, "ASCTABLE") == 0 || strcaselesscmp(cp, "ASCIITABLE") == 0) {
 
     int astart, aend;
 
@@ -1472,7 +1472,7 @@ int parse_directive(void) {
 
   /* ASC? */
 
-  if (strcmp(cp, "ASC") == 0) {
+  if (strcaselesscmp(cp, "ASC") == 0) {
     strcpy(bak, cp);
 
     if (asciitable_defined == 0) {
@@ -1520,7 +1520,7 @@ int parse_directive(void) {
 
   /* DW/WORD? */
 
-  if (strcmp(cp, "DW") == 0 || strcmp(cp, "WORD") == 0) {
+  if (strcaselesscmp(cp, "DW") == 0 || strcaselesscmp(cp, "WORD") == 0) {
     strcpy(bak, cp);
 
     inz = input_number();
@@ -1558,7 +1558,7 @@ int parse_directive(void) {
 
   /* DSTRUCT */
 
-  if (strcmp(cp, "DSTRUCT") == 0) {
+  if (strcaselesscmp(cp, "DSTRUCT") == 0) {
 
     struct structure_item *it;
     struct structure *s;
@@ -1717,7 +1717,7 @@ int parse_directive(void) {
 
   /* DS/DSB? */
 
-  if (strcmp(cp, "DSB") == 0 || strcmp(cp, "DS") == 0) {
+  if (strcaselesscmp(cp, "DSB") == 0 || strcaselesscmp(cp, "DS") == 0) {
     strcpy(bak, cp);
 
     q = input_number();
@@ -1769,7 +1769,7 @@ int parse_directive(void) {
 
   /* DSW? */
 
-  if (strcmp(cp, "DSW") == 0) {
+  if (strcaselesscmp(cp, "DSW") == 0) {
     q = input_number();
     if (q == FAILED)
       return FAILED;
@@ -1817,7 +1817,7 @@ int parse_directive(void) {
 
   /* INCDIR */
 
-  if (strcmp(cp, "INCDIR") == 0) {
+  if (strcaselesscmp(cp, "INCDIR") == 0) {
 
     char *c;
 
@@ -1871,7 +1871,7 @@ int parse_directive(void) {
 
   /* INCLUDE */
 
-  if (strcmp(cp, "INCLUDE") == 0) {
+  if (strcaselesscmp(cp, "INCLUDE") == 0) {
     o = input_number();
     if (o != INPUT_NUMBER_STRING) {
       print_error(".INCLUDE needs a file name string.\n", ERROR_DIR);
@@ -1895,7 +1895,7 @@ int parse_directive(void) {
 
   /* INCBIN */
 
-  if (strcmp(cp, "INCBIN") == 0) {
+  if (strcaselesscmp(cp, "INCBIN") == 0) {
 
     struct macro_static *m;
     int s, r, j;
@@ -1950,7 +1950,7 @@ int parse_directive(void) {
 
   /* OUTNAME */
 
-  if (strcmp(cp, "OUTNAME") == 0) {
+  if (strcaselesscmp(cp, "OUTNAME") == 0) {
 
     inz = input_number();
 
@@ -1966,7 +1966,7 @@ int parse_directive(void) {
 
   /* STRUCT */
 
-  if (strcmp(cp, "STRUCT") == 0) {
+  if (strcaselesscmp(cp, "STRUCT") == 0) {
 
     struct structure_item *si, *ss, *sl = NULL;
     struct structure *st;
@@ -2174,7 +2174,7 @@ int parse_directive(void) {
 
   /* RAMSECTION */
 
-  if (strcmp(cp, "RAMSECTION") == 0) {
+  if (strcaselesscmp(cp, "RAMSECTION") == 0) {
 
     char namebak[256];
 
@@ -2418,7 +2418,7 @@ int parse_directive(void) {
 
   /* SECTION */
 
-  if (strcmp(cp, "SECTION") == 0) {
+  if (strcaselesscmp(cp, "SECTION") == 0) {
 
     int l, m;
 
@@ -2650,7 +2650,7 @@ int parse_directive(void) {
 
   /* ELSE */
 
-  if (strcmp(cp, "ELSE") == 0) {
+  if (strcaselesscmp(cp, "ELSE") == 0) {
 
     int m, r;
 
@@ -2667,13 +2667,13 @@ int parse_directive(void) {
     macro_active = 0;
     while (get_next_token() != FAILED) {
       if (tmp[0] == '.') {
-        if (strcmp(cp, "ENDIF") == 0)
+        if (strcaselesscmp(cp, "ENDIF") == 0)
           r--;
-        if (strcmp(cp, "E") == 0)
+        if (strcaselesscmp(cp, "E") == 0)
           break;
-        if (strcmp(cp, "IFDEF") == 0 || strcmp(cp, "IFNDEF") == 0 || strcmp(cp, "IFGR") == 0 || strcmp(cp, "IFLE") == 0 || strcmp(cp, "IFEQ") == 0 ||
-            strcmp(cp, "IFNEQ") == 0 || strcmp(cp, "IFDEFM") == 0 || strcmp(cp, "IFNDEFM") == 0 || strcmp(cp, "IF") == 0 || strcmp(cp, "IFEXISTS") == 0 ||
-            strcmp(cp, "IFGREQ") == 0 || strcmp(cp, "IFLEEQ") == 0)
+        if (strcaselesscmp(cp, "IFDEF") == 0 || strcaselesscmp(cp, "IFNDEF") == 0 || strcaselesscmp(cp, "IFGR") == 0 || strcaselesscmp(cp, "IFLE") == 0 || strcaselesscmp(cp, "IFEQ") == 0 ||
+            strcaselesscmp(cp, "IFNEQ") == 0 || strcaselesscmp(cp, "IFDEFM") == 0 || strcaselesscmp(cp, "IFNDEFM") == 0 || strcaselesscmp(cp, "IF") == 0 || strcaselesscmp(cp, "IFEXISTS") == 0 ||
+            strcaselesscmp(cp, "IFGREQ") == 0 || strcaselesscmp(cp, "IFLEEQ") == 0)
           r++;
       }
       if (r == 0) {
@@ -2689,7 +2689,7 @@ int parse_directive(void) {
 
   /* ENDIF */
 
-  if (strcmp(cp, "ENDIF") == 0) {
+  if (strcaselesscmp(cp, "ENDIF") == 0) {
     if (ifdef == 0) {
       print_error(".ENDIF was given before any .IF directive.\n", ERROR_DIR);
       return FAILED;
@@ -2701,7 +2701,7 @@ int parse_directive(void) {
 
   /* IFDEF */
 
-  if (strcmp(cp, "IFDEF") == 0) {
+  if (strcaselesscmp(cp, "IFDEF") == 0) {
 
     struct definition *d;
 
@@ -2723,7 +2723,7 @@ int parse_directive(void) {
 
   /* IF */
 
-  if (strcmp(cp, "IF") == 0) {
+  if (strcaselesscmp(cp, "IF") == 0) {
 
     char k[256];
     int y, o, s;
@@ -2799,7 +2799,7 @@ int parse_directive(void) {
 
   /* IFGR/IFLE/IFEQ/IFNEQ/IFGREQ/IFLEEQ */
 
-  if (strcmp(cp, "IFGR") == 0 || strcmp(cp, "IFLE") == 0 || strcmp(cp, "IFEQ") == 0 || strcmp(cp, "IFNEQ") == 0 || strcmp(cp, "IFGREQ") == 0 || strcmp(cp, "IFLEEQ") == 0) {
+  if (strcaselesscmp(cp, "IFGR") == 0 || strcaselesscmp(cp, "IFLE") == 0 || strcaselesscmp(cp, "IFEQ") == 0 || strcaselesscmp(cp, "IFNEQ") == 0 || strcaselesscmp(cp, "IFGREQ") == 0 || strcaselesscmp(cp, "IFLEEQ") == 0) {
 
     char k[256];
     int y, o, s;
@@ -2872,7 +2872,7 @@ int parse_directive(void) {
 
   /* IFEXISTS */
 
-  if (strcmp(cp, "IFEXISTS") == 0) {
+  if (strcaselesscmp(cp, "IFEXISTS") == 0) {
 
     FILE *f;
 
@@ -2896,7 +2896,7 @@ int parse_directive(void) {
 
   /* IFNDEF */
 
-  if (strcmp(cp, "IFNDEF") == 0) {
+  if (strcaselesscmp(cp, "IFNDEF") == 0) {
 
     struct definition *d;
 
@@ -2919,7 +2919,7 @@ int parse_directive(void) {
 
   /* IFDEFM/IFNDEFM */
 
-  if (strcmp(cp, "IFDEFM") == 0 || strcmp(cp, "IFNDEFM") == 0) {
+  if (strcaselesscmp(cp, "IFDEFM") == 0 || strcaselesscmp(cp, "IFNDEFM") == 0) {
 
     int k, o;
     char e;
@@ -2976,7 +2976,7 @@ int parse_directive(void) {
 
   /* FOPEN */
 
-  if (strcmp(cp, "FOPEN") == 0) {
+  if (strcaselesscmp(cp, "FOPEN") == 0) {
 
     struct filepointer *f;
     char *c;
@@ -3051,7 +3051,7 @@ int parse_directive(void) {
 
   /* FCLOSE */
 
-  if (strcmp(cp, "FCLOSE") == 0) {
+  if (strcaselesscmp(cp, "FCLOSE") == 0) {
 
     struct filepointer *f, **t;
 
@@ -3090,7 +3090,7 @@ int parse_directive(void) {
 
   /* FSIZE */
 
-  if (strcmp(cp, "FSIZE") == 0) {
+  if (strcaselesscmp(cp, "FSIZE") == 0) {
 
     struct filepointer *f;
     long l, b;
@@ -3130,7 +3130,7 @@ int parse_directive(void) {
 
   /* FREAD */
 
-  if (strcmp(cp, "FREAD") == 0) {
+  if (strcaselesscmp(cp, "FREAD") == 0) {
 
     struct filepointer *f;
     unsigned char c;
@@ -3167,7 +3167,7 @@ int parse_directive(void) {
 
   /* BLOCK */
 
-  if (strcmp(cp, "BLOCK") == 0) {
+  if (strcaselesscmp(cp, "BLOCK") == 0) {
     if ((ind = get_next_token()) == FAILED)
       return FAILED;
 
@@ -3186,7 +3186,7 @@ int parse_directive(void) {
 
   /* ENDB */
 
-  if (strcmp(cp, "ENDB") == 0) {
+  if (strcaselesscmp(cp, "ENDB") == 0) {
 
     if (block_status <= 0) {
       print_error("There is no open .BLOCK.\n", ERROR_DIR);
@@ -3201,7 +3201,7 @@ int parse_directive(void) {
 
   /* SHIFT */
 
-  if (strcmp(cp, "SHIFT") == 0) {
+  if (strcaselesscmp(cp, "SHIFT") == 0) {
 
     struct macro_argument *ma;
     struct macro_runtime *rt;
@@ -3266,7 +3266,7 @@ int parse_directive(void) {
 #ifdef GB
   /* NAME */
 
-  if (strcmp(cp, "NAME") == 0) {
+  if (strcaselesscmp(cp, "NAME") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .NAME.\n", ERROR_DIR);
       return FAILED;
@@ -3318,7 +3318,7 @@ int parse_directive(void) {
 #ifdef W65816
   /* NAME */
 
-  if (strcmp(cp, "NAME") == 0) {
+  if (strcaselesscmp(cp, "NAME") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .NAME.\n", ERROR_DIR);
       return FAILED;
@@ -3370,7 +3370,7 @@ int parse_directive(void) {
 
   /* ENDS */
 
-  if (strcmp(cp, "ENDS") == 0) {
+  if (strcaselesscmp(cp, "ENDS") == 0) {
 
     if (section_status == OFF) {
       print_error("There is no open section.\n", ERROR_DIR);
@@ -3386,7 +3386,7 @@ int parse_directive(void) {
 
   /* ROMBANKS */
 
-  if (strcmp(cp, "ROMBANKS") == 0) {
+  if (strcaselesscmp(cp, "ROMBANKS") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ROMBANKS.\n", ERROR_DIR);
@@ -3499,7 +3499,7 @@ int parse_directive(void) {
 
   /* ROMBANKMAP */
 
-  if (strcmp(cp, "ROMBANKMAP") == 0) {
+  if (strcaselesscmp(cp, "ROMBANKMAP") == 0) {
 
     int b = 0, a = 0, bt = 0, bt_defined = 0, x, bs = 0, bs_defined = 0;
 
@@ -3757,7 +3757,7 @@ int parse_directive(void) {
 
   /* MEMORYMAP */
 
-  if (strcmp(cp, "MEMORYMAP") == 0) {
+  if (strcaselesscmp(cp, "MEMORYMAP") == 0) {
 
     int slotsize = 0, slotsize_defined = 0, s = 0;
 
@@ -3893,7 +3893,7 @@ int parse_directive(void) {
 
   /* UNBACKGROUND */
 
-  if (strcmp(cp, "UNBACKGROUND") == 0) {
+  if (strcaselesscmp(cp, "UNBACKGROUND") == 0) {
 
     int start, end;
 
@@ -3955,7 +3955,7 @@ int parse_directive(void) {
 
   /* BACKGROUND */
 
-  if (strcmp(cp, "BACKGROUND") == 0) {
+  if (strcaselesscmp(cp, "BACKGROUND") == 0) {
 
     FILE *file_in_ptr;
 
@@ -4017,7 +4017,7 @@ int parse_directive(void) {
 #ifdef GB
   /* RAMSIZE */
 
-  if (strcmp(cp, "RAMSIZE") == 0) {
+  if (strcaselesscmp(cp, "RAMSIZE") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .RAMSIZE.\n", ERROR_DIR);
@@ -4055,7 +4055,7 @@ int parse_directive(void) {
 
   /* COUNTRYCODE */
 
-  if (strcmp(cp, "COUNTRYCODE") == 0) {
+  if (strcaselesscmp(cp, "COUNTRYCODE") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .COUNTRYCODE.\n", ERROR_DIR);
@@ -4088,7 +4088,7 @@ int parse_directive(void) {
 
   /* CARTRIDGETYPE */
 
-  if (strcmp(cp, "CARTRIDGETYPE") == 0) {
+  if (strcaselesscmp(cp, "CARTRIDGETYPE") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .CARTRIDGETYPE.\n", ERROR_DIR);
@@ -4120,7 +4120,7 @@ int parse_directive(void) {
 
   /* LICENSEECODENEW */
 
-  if (strcmp(cp, "LICENSEECODENEW") == 0) {
+  if (strcaselesscmp(cp, "LICENSEECODENEW") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .LICENSEECODENEW.\n", ERROR_DIR);
@@ -4160,7 +4160,7 @@ int parse_directive(void) {
 
   /* LICENSEECODEOLD */
 
-  if (strcmp(cp, "LICENSEECODEOLD") == 0) {
+  if (strcaselesscmp(cp, "LICENSEECODEOLD") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .LICENSEECODEOLD.\n", ERROR_DIR);
@@ -4197,7 +4197,7 @@ int parse_directive(void) {
 
   /* EMPTYFILL */
 
-  if (strcmp(cp, "EMPTYFILL") == 0) {
+  if (strcaselesscmp(cp, "EMPTYFILL") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .EMPTYFILL.\n", ERROR_DIR);
@@ -4229,7 +4229,7 @@ int parse_directive(void) {
 
   /* DEFINE/DEF/EQU */
 
-  if (strcmp(cp, "DEFINE") == 0 || strcmp(cp, "DEF") == 0 || strcmp(cp, "EQU") == 0) {
+  if (strcaselesscmp(cp, "DEFINE") == 0 || strcaselesscmp(cp, "DEF") == 0 || strcaselesscmp(cp, "EQU") == 0) {
 
     double dou;
     char k[256];
@@ -4281,7 +4281,7 @@ int parse_directive(void) {
 
   /* INPUT */
 
-  if (strcmp(cp, "INPUT") == 0) {
+  if (strcaselesscmp(cp, "INPUT") == 0) {
 
     char k[256];
     int j, v;
@@ -4378,7 +4378,7 @@ int parse_directive(void) {
 
   /* REDEFINE/REDEF */
 
-  if (strcmp(cp, "REDEFINE") == 0 || strcmp(cp, "REDEF") == 0) {
+  if (strcaselesscmp(cp, "REDEFINE") == 0 || strcaselesscmp(cp, "REDEF") == 0) {
 
     double dou;
     char k[256];
@@ -4429,7 +4429,7 @@ int parse_directive(void) {
 
   /* EXPORT */
 
-  if (strcmp(cp, "EXPORT") == 0) {
+  if (strcaselesscmp(cp, "EXPORT") == 0) {
     q = 0;
     while (1) {
       ind = input_next_string();
@@ -4455,7 +4455,7 @@ int parse_directive(void) {
 
   /* SYM/SYMBOL */
 
-  if (strcmp(cp, "SYM") == 0 || strcmp(cp, "SYMBOL") == 0) {
+  if (strcaselesscmp(cp, "SYM") == 0 || strcaselesscmp(cp, "SYMBOL") == 0) {
     ind = input_next_string();
     if (ind != SUCCEEDED) {
       print_error(".SYM requires a symbol name.\n", ERROR_DIR);
@@ -4469,14 +4469,14 @@ int parse_directive(void) {
 
   /* BR/BREAKPOINT */
 
-  if (strcmp(cp, "BR") == 0 || strcmp(cp, "BREAKPOINT") == 0) {
+  if (strcaselesscmp(cp, "BR") == 0 || strcaselesscmp(cp, "BREAKPOINT") == 0) {
     fprintf(file_out_ptr, "Z ");
     return SUCCEEDED;
   }
 
   /* ENUM */
 
-  if (strcmp(cp, "ENUM") == 0) {
+  if (strcaselesscmp(cp, "ENUM") == 0) {
 
     char tmpname[MAX_NAME_LENGTH];
     int exp = NO, ord = 1, type;
@@ -4681,7 +4681,7 @@ int parse_directive(void) {
 #ifdef GB
   /* COMPUTEGBCHECKSUM */
 
-  if (strcmp(cp, "COMPUTECHECKSUM") == 0 || strcmp(cp, "COMPUTEGBCHECKSUM") == 0) {
+  if (strcaselesscmp(cp, "COMPUTECHECKSUM") == 0 || strcaselesscmp(cp, "COMPUTEGBCHECKSUM") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .COMPUTEGBCHECKSUM.\n", ERROR_DIR);
@@ -4695,7 +4695,7 @@ int parse_directive(void) {
 
   /* COMPUTEGBCOMPLEMENTCHECK */
 
-  if (strcmp(cp, "COMPUTEGBCOMPLEMENTCHECK") == 0 || strcmp(cp, "COMPUTECOMPLEMENTCHECK") == 0) {
+  if (strcaselesscmp(cp, "COMPUTEGBCOMPLEMENTCHECK") == 0 || strcaselesscmp(cp, "COMPUTECOMPLEMENTCHECK") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .COMPUTEGBCOMPLEMENTCHECK.\n", ERROR_DIR);
@@ -4711,7 +4711,7 @@ int parse_directive(void) {
 #ifdef W65816
   /* COMPUTESNESCHECKSUM */
 
-  if (strcmp(cp, "COMPUTESNESCHECKSUM") == 0) {
+  if (strcaselesscmp(cp, "COMPUTESNESCHECKSUM") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .COMPUTESNESCHECKSUM.\n", ERROR_DIR);
@@ -4733,7 +4733,7 @@ int parse_directive(void) {
 #ifdef Z80
   /* COMPUTESMSCHECKSUM */
 
-  if (strcmp(cp, "COMPUTESMSCHECKSUM") == 0) {
+  if (strcaselesscmp(cp, "COMPUTESMSCHECKSUM") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .COMPUTESMSCHECKSUM.\n", ERROR_DIR);
@@ -4745,7 +4745,7 @@ int parse_directive(void) {
     return SUCCEEDED;
   }
 
-  if (strcmp(cp, "SMSTAG") == 0) {
+  if (strcaselesscmp(cp, "SMSTAG") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .SMSTAG.\n", ERROR_DIR);
@@ -4760,7 +4760,7 @@ int parse_directive(void) {
 
   /* SDSCTAG */
 
-  if (strcmp(cp, "SDSCTAG") == 0) {
+  if (strcaselesscmp(cp, "SDSCTAG") == 0) {
 
     if (sdsctag_defined != 0) {
       print_error(".SDSCTAG can be defined only once.\n", ERROR_DIR);
@@ -4899,7 +4899,7 @@ int parse_directive(void) {
 
   /* MACRO */
 
-  if (strcmp(cp, "MACRO") == 0) {
+  if (strcaselesscmp(cp, "MACRO") == 0) {
 
     struct macro_static *m;
     int macro_start_line;
@@ -4908,7 +4908,7 @@ int parse_directive(void) {
     if (get_next_token() == FAILED)
       return FAILED;
 
-    if (strcmp(cp, "ENDM") == 0) {
+    if (strcaselesscmp(cp, "ENDM") == 0) {
       print_error("A MACRO must have a name.\n", ERROR_DIR);
       return FAILED;
     }
@@ -5006,7 +5006,7 @@ int parse_directive(void) {
 
   /* REPT/REPEAT */
 
-  if (strcmp(cp, "REPT") == 0 || strcmp(cp, "REPEAT") == 0) {
+  if (strcaselesscmp(cp, "REPT") == 0 || strcaselesscmp(cp, "REPEAT") == 0) {
 
     char c[16], index_name[MAX_NAME_LENGTH];
 
@@ -5053,11 +5053,11 @@ int parse_directive(void) {
       macro_active = 0;
       while (get_next_token() != FAILED) {
         if (tmp[0] == '.') {
-          if (strcmp(cp, "ENDR") == 0)
+          if (strcaselesscmp(cp, "ENDR") == 0)
             r--;
-          if (strcmp(cp, "E") == 0)
+          if (strcaselesscmp(cp, "E") == 0)
             break;
-          if (strcmp(cp, "REPT") == 0 || strcmp(cp, "REPEAT") == 0)
+          if (strcaselesscmp(cp, "REPT") == 0 || strcaselesscmp(cp, "REPEAT") == 0)
             r++;
         }
         if (r == 0) {
@@ -5098,7 +5098,7 @@ int parse_directive(void) {
 
   /* ENDR */
 
-  if (strcmp(cp, "ENDR") == 0) {
+  if (strcaselesscmp(cp, "ENDR") == 0) {
 
     struct repeat_runtime *rr = NULL;
     
@@ -5129,7 +5129,7 @@ int parse_directive(void) {
 
   /* E */
 
-  if (strcmp(cp, "E") == 0) {
+  if (strcaselesscmp(cp, "E") == 0) {
     if (active_file_info_last != NULL) {
       active_file_info_tmp = active_file_info_last;
       active_file_info_last = active_file_info_last->prev;
@@ -5156,7 +5156,7 @@ int parse_directive(void) {
 
   /* M */
 
-  if (strcmp(cp, "M") == 0) {
+  if (strcaselesscmp(cp, "M") == 0) {
     if (line_count_status == OFF)
       line_count_status = ON;
     else
@@ -5167,7 +5167,7 @@ int parse_directive(void) {
 #ifdef GB
   /* ROMGBC */
 
-  if (strcmp(cp, "ROMGBC") == 0) {
+  if (strcaselesscmp(cp, "ROMGBC") == 0) {
 
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ROMGBC.\n", ERROR_DIR);
@@ -5185,7 +5185,7 @@ int parse_directive(void) {
 
   /* ROMDMG */
 
-  if (strcmp(cp, "ROMDMG") == 0) {
+  if (strcaselesscmp(cp, "ROMDMG") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ROMDMG.\n", ERROR_DIR);
       return FAILED;
@@ -5206,7 +5206,7 @@ int parse_directive(void) {
 
   /* ROMSGB */
 
-  if (strcmp(cp, "ROMSGB") == 0) {
+  if (strcaselesscmp(cp, "ROMSGB") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .ROMSGB.\n", ERROR_DIR);
       return FAILED;
@@ -5224,7 +5224,7 @@ int parse_directive(void) {
 
   /* ROMBANKSIZE */
 
-  if (strcmp(cp, "ROMBANKSIZE") == 0 || strcmp(cp, "BANKSIZE") == 0) {
+  if (strcaselesscmp(cp, "ROMBANKSIZE") == 0 || strcaselesscmp(cp, "BANKSIZE") == 0) {
     q = input_number();
 
     if (q == FAILED)
@@ -5250,7 +5250,7 @@ int parse_directive(void) {
 
   /* ENDM */
 
-  if (strcmp(cp, "ENDM") == 0) {
+  if (strcaselesscmp(cp, "ENDM") == 0) {
     if (macro_active != 0) {
       macro_active--;
 
@@ -5339,14 +5339,14 @@ int parse_directive(void) {
 
   /* 8BIT */
 
-  if (strcmp(cp, "8BIT") == 0) {
+  if (strcaselesscmp(cp, "8BIT") == 0) {
     xbit_size = 8;
     return SUCCEEDED;
   }
 
   /* 16BIT */
 
-  if (strcmp(cp, "16BIT") == 0) {
+  if (strcaselesscmp(cp, "16BIT") == 0) {
     xbit_size = 16;
     return SUCCEEDED;
   }
@@ -5357,14 +5357,14 @@ int parse_directive(void) {
 
   /* 24BIT */
 
-  if (strcmp(cp, "24BIT") == 0) {
+  if (strcaselesscmp(cp, "24BIT") == 0) {
     xbit_size = 24;
     return SUCCEEDED;
   }
 
   /* INDEX */
 
-  if (strcmp(cp, "INDEX") == 0) {
+  if (strcaselesscmp(cp, "INDEX") == 0) {
     q = input_number();
 
     if (q == FAILED)
@@ -5381,7 +5381,7 @@ int parse_directive(void) {
 
   /* ACCU */
 
-  if (strcmp(cp, "ACCU") == 0) {
+  if (strcaselesscmp(cp, "ACCU") == 0) {
     q = input_number();
 
     if (q == FAILED)
@@ -5398,7 +5398,7 @@ int parse_directive(void) {
 
   /* BASE */
 
-  if (strcmp(cp, "BASE") == 0) {
+  if (strcaselesscmp(cp, "BASE") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .BASE definitions.\n", ERROR_DIR);
       return FAILED;
@@ -5420,7 +5420,7 @@ int parse_directive(void) {
 
   /* SMC */
 
-  if (strcmp(cp, "SMC") == 0) {
+  if (strcaselesscmp(cp, "SMC") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .SMC.\n", ERROR_DIR);
       return FAILED;
@@ -5434,7 +5434,7 @@ int parse_directive(void) {
 
   /* HIROM */
 
-  if (strcmp(cp, "HIROM") == 0) {
+  if (strcaselesscmp(cp, "HIROM") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .HIROM.\n", ERROR_DIR);
       return FAILED;
@@ -5452,7 +5452,7 @@ int parse_directive(void) {
 
   /* LOROM */
 
-  if (strcmp(cp, "LOROM") == 0) {
+  if (strcaselesscmp(cp, "LOROM") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .LOROM.\n", ERROR_DIR);
       return FAILED;
@@ -5470,7 +5470,7 @@ int parse_directive(void) {
 
   /* SLOWROM */
 
-  if (strcmp(cp, "SLOWROM") == 0) {
+  if (strcaselesscmp(cp, "SLOWROM") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .SLOWROM.\n", ERROR_DIR);
       return FAILED;
@@ -5488,7 +5488,7 @@ int parse_directive(void) {
 
   /* FASTROM */
 
-  if (strcmp(cp, "FASTROM") == 0) {
+  if (strcaselesscmp(cp, "FASTROM") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .FASTROM.\n", ERROR_DIR);
       return FAILED;
@@ -5506,7 +5506,7 @@ int parse_directive(void) {
 
   /* SNESHEADER */
 
-  if (strcmp(cp, "SNESHEADER") == 0) {
+  if (strcaselesscmp(cp, "SNESHEADER") == 0) {
     if (snesheader_defined != 0) {
       print_error(".SNESHEADER can be defined only once.\n", ERROR_DIR);
       return FAILED;
@@ -5769,7 +5769,7 @@ int parse_directive(void) {
 
   /* SNESNATIVEVECTOR */
 
-  if (strcmp(cp, "SNESNATIVEVECTOR") == 0) {
+  if (strcaselesscmp(cp, "SNESNATIVEVECTOR") == 0) {
 
     int cop_defined = 0, brk_defined = 0, abort_defined = 0;
     int nmi_defined = 0, unused_defined = 0, irq_defined = 0;
@@ -5973,7 +5973,7 @@ int parse_directive(void) {
 
   /* SNESEMUVECTOR */
 
-  if (strcmp(cp, "SNESEMUVECTOR") == 0) {
+  if (strcaselesscmp(cp, "SNESEMUVECTOR") == 0) {
 
     int cop_defined = 0, unused_defined = 0, abort_defined = 0;
     int nmi_defined = 0, reset_defined = 0, irqbrk_defined = 0;
@@ -6179,7 +6179,7 @@ int parse_directive(void) {
 
   /* PRINTT */
 
-  if (strcmp(cp, "PRINTT") == 0) {
+  if (strcaselesscmp(cp, "PRINTT") == 0) {
 
     char t[256];
     int s, u;
@@ -6219,7 +6219,7 @@ int parse_directive(void) {
 
   /* PRINTV */
 
-  if (strcmp(cp, "PRINTV") == 0) {
+  if (strcaselesscmp(cp, "PRINTV") == 0) {
 
     int m;
 
@@ -6260,7 +6260,7 @@ int parse_directive(void) {
 
   /* SEED */
 
-  if (strcmp(cp, "SEED") == 0) {
+  if (strcaselesscmp(cp, "SEED") == 0) {
 
     q = input_number();
     if (q == FAILED)
@@ -6278,7 +6278,7 @@ int parse_directive(void) {
 
   /* DBRND/DWRND */
 
-  if (strcmp(cp, "DBRND") == 0 || strcmp(cp, "DWRND") == 0) {
+  if (strcaselesscmp(cp, "DBRND") == 0 || strcaselesscmp(cp, "DWRND") == 0) {
 
     int o, c, min, max, f;
 
@@ -6365,7 +6365,7 @@ int parse_directive(void) {
 
   /* DWSIN/DBSIN/DWCOS/DBCOS */
 
-  if (strcmp(cp, "DWSIN") == 0 || strcmp(cp, "DBSIN") == 0 || strcmp(cp, "DWCOS") == 0 || strcmp(cp, "DBCOS") == 0) {
+  if (strcaselesscmp(cp, "DWSIN") == 0 || strcaselesscmp(cp, "DBSIN") == 0 || strcaselesscmp(cp, "DWCOS") == 0 || strcaselesscmp(cp, "DBCOS") == 0) {
 
     double m, a, s, n;
     int p, c, o, f;
@@ -6473,7 +6473,7 @@ int parse_directive(void) {
 
   /* FAIL */
 
-  if (strcmp(cp, "FAIL") == 0) {
+  if (strcaselesscmp(cp, "FAIL") == 0) {
     print_error("HALT: .FAIL found.\n", ERROR_NONE);
 
     /* make a silent exit */
@@ -6482,7 +6482,7 @@ int parse_directive(void) {
 
   /* UNDEF/UNDEFINE */
 
-  if (strcmp(cp, "UNDEF") == 0 || strcmp(cp, "UNDEFINE") == 0) {
+  if (strcaselesscmp(cp, "UNDEF") == 0 || strcaselesscmp(cp, "UNDEFINE") == 0) {
 
     char c[16];
 
@@ -6517,12 +6517,12 @@ int parse_directive(void) {
 
   /* ASM */
 
-  if (strcmp(cp, "ASM") == 0)
+  if (strcaselesscmp(cp, "ASM") == 0)
     return SUCCEEDED;
 
   /* ENDASM */
 
-  if (strcmp(cp, "ENDASM") == 0) {
+  if (strcaselesscmp(cp, "ENDASM") == 0) {
 
     int endasm = 1, x;
 
@@ -6568,19 +6568,19 @@ int find_next_point(char *name) {
   macro_active = 0;
   while (get_next_token() != FAILED) {
     if (tmp[0] == '.') {
-      if (strcmp(cp, "ENDIF") == 0)
+      if (strcaselesscmp(cp, "ENDIF") == 0)
         depth--;
-      if (strcmp(cp, "ELSE") == 0 && depth == 1)
+      if (strcaselesscmp(cp, "ELSE") == 0 && depth == 1)
         depth--;
-      if (strcmp(cp, "E") == 0)
+      if (strcaselesscmp(cp, "E") == 0)
         break;
-      if (strcmp(cp, "IFDEF") == 0 || strcmp(cp, "IFNDEF") == 0 || strcmp(cp, "IFGR") == 0 || strcmp(cp, "IFLE") == 0 ||
-          strcmp(cp, "IFEQ") == 0 || strcmp(cp, "IFNEQ") == 0 || strcmp(cp, "IFDEFM") == 0 || strcmp(cp, "IFNDEFM") == 0 ||
-          strcmp(cp, "IF") == 0 || strcmp(cp, "IFGREQ") == 0 || strcmp(cp, "IFLEEQ") == 0 || strcmp(cp, "IFEXISTS") == 0)
+      if (strcaselesscmp(cp, "IFDEF") == 0 || strcaselesscmp(cp, "IFNDEF") == 0 || strcaselesscmp(cp, "IFGR") == 0 || strcaselesscmp(cp, "IFLE") == 0 ||
+          strcaselesscmp(cp, "IFEQ") == 0 || strcaselesscmp(cp, "IFNEQ") == 0 || strcaselesscmp(cp, "IFDEFM") == 0 || strcaselesscmp(cp, "IFNDEFM") == 0 ||
+          strcaselesscmp(cp, "IF") == 0 || strcaselesscmp(cp, "IFGREQ") == 0 || strcaselesscmp(cp, "IFLEEQ") == 0 || strcaselesscmp(cp, "IFEXISTS") == 0)
         depth++;
     }
     if (depth == 0) {
-      if (strcmp(cp, "ELSE") == 0)
+      if (strcaselesscmp(cp, "ELSE") == 0)
         ifdef++;
       macro_active = m;
       return SUCCEEDED;


### PR DESCRIPTION
While this is kind of a don't fix what isn't broken situation, it's just kind of weird that half the directives use strcmp and the other half uses strcaselesscmp. If you're going to write your own substitute to a function, might as well use it, so.