### PR TITLE
Fix bug with references

### DIFF
--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -662,6 +662,8 @@ int fix_references(void) {
   /* insert references */
   r = reference_first;
   while (r != NULL) {
+    s = NULL;
+
     x = r->address;
     /* search for the section of the reference and fix the address */
     if (r->section_status == ON) {


### PR DESCRIPTION
Stuff like this was actually compiling.

```
.section "section"

_local:

.ends

call _local
```