### PR TITLE
Added .NINTENDOLOGO for gameboy roms

### DIFF
--- a/README
+++ b/README
@@ -135,6 +135,7 @@ Group 2:
 
 [GB ] .CARTRIDGETYPE 1
 [GB ] .COUNTRYCODE 1
+[GB ] .NINTENDOLOGO
 [GB ] .GBHEADER
 [GB ] .COMPUTEGBCOMPLEMENTCHECK
 [ALL] .EMPTYFILL $C9
@@ -544,6 +545,14 @@ This is not a compulsory directive.
 --------------
 
 Indicates the country code located at $14A of a Gameboy ROM.
+
+This is not a compulsory directive.
+
+-------------
+.NINTENDOLOGO
+-------------
+
+Places the required Nintendo logo into the Gameboy ROM at $104.
 
 This is not a compulsory directive.
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -20,6 +20,7 @@
 #ifdef GB
 char licenseecodenew_c1, licenseecodenew_c2;
 int gbheader_defined = 0;
+int nintendologo_defined = 0;
 int computechecksum_defined = 0, computecomplementcheck_defined = 0;
 int romgbc = 0, romdmg = 0, romsgb = 0;
 int cartridgetype = 0, cartridgetype_defined = 0;
@@ -3436,9 +3437,22 @@ int parse_directive(void) {
   }
 
 #ifdef GB
+  /* NINTENDOLOGO */
+  
+  if (strcaselesscmp(cp, "NINTENDOLOGO") == 0) {
+    if (output_format == OUTPUT_LIBRARY) {
+      print_error("Library files don't take .NINTENDOLOGO.\n", ERROR_DIR);
+      return FAILED;
+    }
+
+    nintendologo_defined++;
+
+    return SUCCEEDED;
+  }
+  
   /* NAME */
 
-  if (strcaselesscmp(cp, "NAME") == 0) {
+  else if (strcaselesscmp(cp, "NAME") == 0) {
     if (output_format == OUTPUT_LIBRARY) {
       print_error("Library files don't take .NAME.\n", ERROR_DIR);
       return FAILED;
@@ -4393,6 +4407,15 @@ int parse_directive(void) {
     while ((ind = get_next_token()) == SUCCEEDED) {
       if (strcaselesscmp(tmp, ".ENDGB") == 0)
         break;
+       
+      else if (strcaselesscmp(cp, "NINTENDOLOGO") == 0) {
+        if (output_format == OUTPUT_LIBRARY) {
+          print_error("Library files don't take .NINTENDOLOGO.\n", ERROR_DIR);
+          return FAILED;
+        }
+
+        nintendologo_defined++;
+      }
       else if (strcaselesscmp(tmp, "ROMDMG") == 0) {
         if (output_format == OUTPUT_LIBRARY) {
           print_error("Library files don't take .ROMDMG.\n", ERROR_DIR);

--- a/pass_2.c
+++ b/pass_2.c
@@ -13,9 +13,19 @@
 
 #ifdef GB
 extern int licenseecodeold;
+extern int nintendologo_defined;
 extern int name_defined, licenseecodeold_defined, licenseecodenew_defined;
 extern int countrycode, countrycode_defined;
 extern char name[32], licenseecodenew_c1, licenseecodenew_c2;
+
+unsigned char nintendo_logo_dat[] = {
+  0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B,
+  0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D,
+  0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E,
+  0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99,
+  0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC,
+  0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E
+};
 #endif
 
 #ifdef Z80
@@ -296,6 +306,17 @@ int pass_2(void) {
 #ifdef GB
   /* insert the descriptive data (not in library files) */
   if (output_format == OUTPUT_OBJECT) {
+    if (nintendologo_defined != 0) {
+      int nl1 = 0x104;
+      unsigned int nl2 = 0;
+      
+      while (nl2 <= sizeof(nintendo_logo_dat)) {
+        mem_insert_absolute(nl1, nintendo_logo_dat[nl2]);
+        nl1++;
+        nl2++;
+      }
+    }
+    
     if (romgbc != 0)
       mem_insert_absolute(323, 128);
     if (romdmg != 0)


### PR DESCRIPTION
Rather than have to manually put in the Nintendo logo for gameboy roms written for wla, you can now just do `.nintendologo` instead.

While this should be an automatic function (as the logo is pretty much mandatory if you want the rom to work on the actual system,) everything out there that already uses WLA-GB puts in the logo manually, and I'd rather not give everyone the inconvenience of looking at a bunch of memory overwrites.