### PR TITLE
wlalink: silent discard sections with -n

### DIFF
--- a/README
+++ b/README
@@ -2909,7 +2909,7 @@ After you have produced one or more object files and perhaps some library
 files, you might want to link them together to produce a ROM image / program
 file. "wlalink" is the program you use for that. Here's how you use it:
 
-"wlalink [-divsS]{b/r} [LIBDIR] <LINK FILE> <OUTPUT FILE>"
+"wlalink [-bdnirsSv] [LIBDIR] <LINK FILE> <OUTPUT FILE>"
 
 Choose 'b' for program file or 'r' for ROM image linking.
 
@@ -2980,6 +2980,9 @@ and definitions.
 If flag 'd' is used, WLALINK discards all unreferenced FREE and SEMIFREE
 sections. This way you can link big libraries to your project and WLALINK
 will choose only the used sections, so you won't be linking any dead code/data.
+
+If flag 'n' is used, WLALINK discards sections as if 'd' were used, but does
+not print to the console whenever a section is discarded.
 
 If flag 'i' is given, WLALINK will write list files. Note that you must
 compile the object and library files with -i flag as well. Otherwise WLALINK

--- a/wlalink/discard.c
+++ b/wlalink/discard.c
@@ -15,6 +15,7 @@ extern struct reference *reference_first, *reference_last;
 extern struct section *sec_first, *sec_last;
 extern struct label *labels_first, *labels_last;
 extern struct stack *stacks_first, *stacks_last;
+extern int silent_discard;
 
 
 int discard_unused_sections(void) {
@@ -51,8 +52,9 @@ int discard_unused_sections(void) {
   s = sec_first;
   while (s != NULL) {
     if (s->alive == NO)
-      fprintf(stderr, "DISCARD: %s:%s: Section \"%s\" was discarded.\n",
-	      get_file_name(s->file_id), get_source_file_name(s->file_id, s->file_id_source), s->name);
+      if (silent_discard == OFF)
+        fprintf(stderr, "DISCARD: %s:%s: Section \"%s\" was discarded.\n",
+	        get_file_name(s->file_id), get_source_file_name(s->file_id, s->file_id_source), s->name);
     s = s->next;
   }
 

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -41,7 +41,7 @@ unsigned char *rom, *rom_usage, *file_header = NULL, *file_footer = NULL;
 int romsize, rombanks, banksize, verbose_mode = OFF, section_overwrite = OFF, symbol_mode = SYMBOL_MODE_NONE;
 int pc_bank, pc_full, pc_slot, pc_slot_max;
 int file_header_size, file_footer_size, *banksizes = NULL, *bankaddress = NULL;
-int output_mode = OUTPUT_ROM, discard_unreferenced_sections = OFF, use_libdir = NO;
+int output_mode = OUTPUT_ROM, discard_unreferenced_sections = OFF, silent_discard = OFF, use_libdir = NO;
 int program_start, program_end, sms_checksum, smstag_defined = 0, snes_rom_mode = SNES_ROM_MODE_LOROM, snes_rom_speed = SNES_ROM_SPEED_SLOWROM;
 int gb_checksum, gb_complement_check, snes_checksum, cpu_65816 = 0, snes_mode = 0;
 int listfile_data = NO, smc_status = 0, snes_sramsize = 0;
@@ -182,10 +182,11 @@ int main(int argc, char *argv[]) {
   if (i == FAILED) {
     printf("\nWLALINK GB-Z80/Z80/6502/65C02/6510/65816/HUC6280/SPC-700 WLA Macro Assembler Linker v5.8b\n");
     printf("Written by Ville Helin in 2000-2008 - In GitHub since 2014: https://github.com/vhelin/wla-dx\n");
-    printf("USAGE: %s [-bdirsSv] -L[LIBDIR] <LINK FILE> <OUTPUT FILE>\n", argv[0]);
+    printf("USAGE: %s [-bdnirsSv] -L[LIBDIR] <LINK FILE> <OUTPUT FILE>\n", argv[0]);
     printf("Options:\n");
     printf("b  Program file output\n");
     printf("d  Discard unreferenced sections\n");
+    printf("n  Silent discard unreferenced sections\n");
     printf("i  Write list files\n");
     printf("r  ROM file output (default)\n");
     printf("s  Write also a NO$GMB symbol file\n");
@@ -719,6 +720,10 @@ int parse_flags(char *f) {
       continue;
     case 'd':
       discard_unreferenced_sections = ON;
+      continue;
+    case 'n':
+      discard_unreferenced_sections = ON;
+      silent_discard = ON;
       continue;
     default:
       return FAILED;


### PR DESCRIPTION
#97. It gets annoying having tons of messages on the command line saying that sections are discarded, so here's an option for the program to keep quiet.