### PR TITLE
Updated .gitignore and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+
+*       text=auto
+*.txt   text
+*.rst   text
+*.c     text
+*.h     text
+*.md    text
+*.sh    text eol=lf
+*.bat   text eol=crlf
+
+# bat-files usually works with LF, but Windows users might have a better
+#   editing time with notepad and CRLF, because nodepad is dumb with LF
+
+linkfile    text
+makefile    text
+*.s     text
+
+README  text
+INSTALL text
+LICENSE text
+CHANGELOG   text
+FILE_FORMATS    text
+
+# Legacy
+SCOPTIONS   text
+amiga   text
+amigaos4    text
+makefile.*  text
+smakefile   text
+scoptions.* text
+smake.* text
+
+# Is there any binary files in this repository?
+# Better be safe.
+*.bin   binary
+*.gb    binary
+*.smc   binary
+*.sfc   binary
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,17 @@ Makefile
 opcodes_*_tables.c
 CMakeCache.txt
 cmake_install.cmake
-CMakeFiles/*
+CMakeFiles/
 opcode_table_generator/makefile
-opcode_table_generator/CMakeFiles/*
-wlalink/CMakeFiles/*
-wlalink/CMakeFiles/wlalink.dir/*
-wlab/CMakeFiles/*
-wlab/CMakeFiles/wlab.dir/*
+opcode_table_generator/CMakeFiles/
+wlalink/CMakeFiles/
+wlab/CMakeFiles/
+
+# Temporary files
+*.bak
+*.swp
+
+# Build directories
+/*build/
+/doc/*build/
+


### PR DESCRIPTION
Updated `.gitignore` to ignore swap-files <sub>(i have vim opened when commiting and git asks me if i want to commit these swap-files..)</sub> and ignore build-directories (usually they are called `<something>build/`, let's ignore them too). Also, some things were "duplicated". Removed these too. (`dir/` ignores `dir` and it's contents, no need for `dir/*`)

Also, add a [`.gitattributes`](https://git-scm.com/docs/gitattributes) file. With `* text`, we say that text-files should be normalized to LF when commiting. This should ensure that the repository is consistent with the line endings. Also, `*.sh` are forced to be LF because they're usually from unix (and they use LF) where `.bat` have CRLF (Windows, you know).