### PR TITLE
Remove the need for a linkfile

### DIFF
--- a/wlalink/files.c
+++ b/wlalink/files.c
@@ -14,261 +14,67 @@
 extern struct object_file *obj_first, *obj_last, *obj_tmp;
 extern struct label *labels_first, *labels_last;
 extern unsigned char *file_header, *file_footer;
-extern int file_header_size, file_footer_size, use_libdir;
+extern int file_header_size, file_footer_size, use_libdir, total_flags;
 char file_name_error[] = "???";
 extern char ext_libdir[MAX_NAME_LENGTH];
 
 
 
-int load_files(char *argv[], int argc) {
+int load_objects(char *argv[], int argc) {
 
-  int state = STATE_NONE, i, x, line, bank, slot, base, bank_defined, slot_defined, base_defined, n;
-  char tmp[1024], token[1024], tmp_token[MAX_NAME_LENGTH];
-  struct label *l;
-  FILE *fop, *f;
+  int i;
 
-  
-  fop = fopen(argv[argc - 2], "rb");
-  if (fop == NULL) {
-    fprintf(stderr, "LOAD_FILES: Could not open file \"%s\".\n", argv[argc - 2]);
-    return FAILED;
+
+  for (i = total_flags + 1; i < argc - 1 ; i++) {
+    if (load_file(argv[i]) == FAILED) return FAILED;
   }
-
-  line = 0;
-  while (fgets(tmp, 255, fop) != NULL) {
-    line++;
-    x = 0;
-
-    if (tmp[0] == ';' || tmp[0] == '*' || tmp[0] == '#' || tmp[0] == 0x0D || tmp[0] == 0x0A)
-      continue;
-
-    /* remove garbage from the end */
-    for (i = 0; !(tmp[i] == 0x0D || tmp[i] == 0x0A); i++)
-      ;
-    tmp[i] = 0;
-
-    /* empty line check */
-    if (get_next_token(tmp, token, &x) == FAILED)
-      continue;
-
-    /* first checks */
-    if (token[0] == '[') {
-      if (strcmp("[objects]", token) == 0) {
-	state = STATE_OBJECT;
-	continue;
-      }
-      else if (strcmp("[libraries]", token) == 0) {
-	state = STATE_LIBRARY;
-	continue;
-      }
-      else if (strcmp("[header]", token) == 0) {
-	state = STATE_HEADER;
-	continue;
-      }
-      else if (strcmp("[footer]", token) == 0) {
-	state = STATE_FOOTER;
-	continue;
-      }
-      else if (strcmp("[definitions]", token) == 0) {
-	state = STATE_DEFINITION;
-	continue;
-      }
-      else {
-	fprintf(stderr, "%s:%d LOAD_FILES: Unknown group \"%s\".\n", argv[argc - 2], line, token);
-	fclose(fop);
-	return FAILED;
-      }
-    }
-
-    if (state == STATE_NONE) {
-      fprintf(stderr, "%s:%d: LOAD_FILES: Before file \"%s\" can be loaded you must define a group for it.\n", argv[argc - 2], line, token);
-      fclose(fop);
-      return FAILED;
-    }
-
-    bank_defined = OFF;
-    slot_defined = OFF;
-    base_defined = OFF;
-    bank = 0;
-    slot = 0;
-    base = 0;
-
-    /* definition loading? */
-    if (state == STATE_DEFINITION) {
-      l = calloc(1, sizeof(struct label));
-      if (l == NULL) {
-	fprintf(stderr, "LOAD_FILES: Out of memory.\n");
-	return FAILED;
-      }
-      strcpy(l->name, token);
-      l->status = LABEL_STATUS_DEFINE;
-      l->bank = 0;
-      l->slot = 0;
-      l->base = 0;
-
-      if (get_next_number(&tmp[x], &n, &x) == FAILED) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: Error in DEFINITION value.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-
-      l->address = n;
-      add_label(l);
-      continue;
-    }
-    /* header loading? */
-    else if (state == STATE_HEADER) {
-      if (file_header != NULL) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: There can be only one header file.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-
-      if (load_file_data(token, &file_header, &file_header_size) == FAILED) {
-	fclose(fop);
-	return FAILED;
-      }
-      if (get_next_token(&tmp[x], token, &x) == FAILED)
-	continue;
-
-      fprintf(stderr, "%s:%d: LOAD_FILES: Syntax error.\n", argv[argc - 2], line);
-      fclose(fop);
-      return FAILED;
-    }
-    /* footer loading? */
-    else if (state == STATE_FOOTER) {
-      if (file_footer != NULL) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: There can be only one footer file.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-
-      if (load_file_data(token, &file_footer, &file_footer_size) == FAILED) {
-	fclose(fop);
-	return FAILED;
-      }
-      if (get_next_token(&tmp[x], token, &x) == FAILED)
-	continue;
-
-      fprintf(stderr, "%s:%d: LOAD_FILES: Syntax error.\n", argv[argc - 2], line);
-      fclose(fop);
-      return FAILED;
-    }
-    /* library loading? */
-    else if (state == STATE_LIBRARY) {
-      i = SUCCEEDED;
-      while (i == SUCCEEDED) {
-	if (strcmp(token, "bank") == 0 || strcmp(token, "BANK") == 0) {
-	  if (bank_defined == ON) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: BANK defined for the second time for a library file.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	  bank_defined = ON;
-	  
-	  if (get_next_number(&tmp[x], &bank, &x) == FAILED) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: Error in BANK number.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	}
-	else if (strcmp(token, "slot") == 0 || strcmp(token, "SLOT") == 0) {
-	  if (slot_defined == ON) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: SLOT defined for the second time for a library file.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	  slot_defined = ON;
-	  
-	  if (get_next_number(&tmp[x], &slot, &x) == FAILED) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: Error in SLOT number.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	}
-	else if (strcmp(token, "base") == 0 || strcmp(token, "BASE") == 0) {
-	  if (base_defined == ON) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: BASE defined for the second time for a library file.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	  base_defined = ON;
-	  
-	  if (get_next_number(&tmp[x], &base, &x) == FAILED) {
-	    fprintf(stderr, "%s:%d: LOAD_FILES: Error in BASE number.\n", argv[argc - 2], line);
-	    fclose(fop);
-	    return FAILED;
-	  }
-	}
-	else
-	  break;
-	
-	i = get_next_token(&tmp[x], token, &x);
-      }
-      
-      if (i == FAILED) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: No library to load.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-      if (slot_defined == OFF) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: Library file requires a SLOT.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-      if (bank_defined == OFF) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: Library file requires a BANK.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-      
-      if (use_libdir == YES) {
-        f = fopen(token, "rb");
-      
-        /* use the current working directory if the library isn't found in the ext_libdir directory */
-        if (f == NULL)
-          sprintf(tmp_token, "%s%s", ext_libdir, token);
-        else {
-          sprintf(tmp_token, "%s", token);
-	  fclose(f);
-	}
-      }
-      else
-        sprintf(tmp_token, "%s", token);
-      
-      if (load_file(tmp_token, bank, slot, base, base_defined) == FAILED) {
-	fclose(fop);
-	return FAILED;
-      }
-      
-      if (get_next_token(&tmp[x], token, &x) == SUCCEEDED) {
-	fprintf(stderr, "%s:%d: LOAD_FILES: Syntax error.\n", argv[argc - 2], line);
-	fclose(fop);
-	return FAILED;
-      }
-      
-      continue;
-    }
-    /* object file loading */
-    else if (load_file(token, 0, 0, 0, OFF) == FAILED) {
-      fclose(fop);
-      return FAILED;
-    }
-    if (get_next_token(&tmp[x], token, &x) == FAILED)
-      continue;
-
-    fprintf(stderr, "%s:%d: LOAD_FILES: Syntax error.\n", argv[argc - 2], line);
-    fclose(fop);
-    return FAILED;
-  }
-
-  fclose(fop);
 
   return SUCCEEDED;
 }
 
 
-int load_file(char *file_name, int bank, int slot, int base, int base_defined) {
+int load_library(char *argv, int contains_flag) {
+
+  char tmp_name[MAX_NAME_LENGTH];
+  FILE *fop;
+
+
+  /* skip the flag? */
+  if (contains_flag == YES)
+    argv += 2;
+
+  if (strlen(argv) < 2)
+    return FAILED;
+
+  /* try the specified path */
+  sprintf(tmp_name, "%s", argv);
+  fop = fopen(argv, "rb");
+
+  if (fop == NULL) {
+	  /* append .lib extension if not found */
+     sprintf(tmp_name, "%s.lib", argv);
+     fop = fopen(tmp_name, "rb");
+
+     if (fop == NULL && use_libdir == YES) {
+	   /* try the lib dir if specified and not found */
+       sprintf(tmp_name, "%s%s", ext_libdir, argv);
+       fop = fopen(tmp_name, "rb");
+
+       if (fop == NULL)
+		 /* append .lib extension if not found */
+         sprintf(tmp_name, "%s%s.lib", ext_libdir, argv);
+	 }
+  }
+
+  fclose(fop);
+
+  if (load_file(tmp_name) == FAILED) return FAILED;
+
+  return SUCCEEDED;
+}
+
+
+int load_file(char *file_name) {
 
   struct object_file *o;
   unsigned char *data;
@@ -294,11 +100,11 @@ int load_file(char *file_name, int bank, int slot, int base, int base_defined) {
     return FAILED;
   }
 
-  /* only valid for library files */
-  o->bank = bank;
-  o->slot = slot;
-  o->base = base;
-  o->base_defined = base_defined;
+  /* only valid for library files; bank 0 slot 0 base 0 assumed unless library is SUPERFREE */
+  o->bank = 0;
+  o->slot = 0;
+  o->base = 0;
+  o->base_defined = OFF;
 
   /* init the rest of the variables */
   o->source_file_names = NULL;

--- a/wlalink/files.c
+++ b/wlalink/files.c
@@ -26,7 +26,7 @@ int load_objects(char *argv[], int argc) {
 
 
   for (i = total_flags; i < argc - 1 ; i++) {
-    if (load_file(argv[i]) == FAILED) return FAILED;
+    if (load_file(argv[i], NULL) == FAILED) return FAILED;
   }
 
   return SUCCEEDED;
@@ -68,13 +68,13 @@ int load_library(char *argv, int contains_flag) {
 
   fclose(fop);
 
-  if (load_file(tmp_name) == FAILED) return FAILED;
+  if (load_file(tmp_name, argv) == FAILED) return FAILED;
 
   return SUCCEEDED;
 }
 
 
-int load_file(char *file_name) {
+int load_file(char *file_name, char *lib_name) {
 
   struct object_file *o;
   unsigned char *data;
@@ -94,7 +94,7 @@ int load_file(char *file_name) {
     return FAILED;
   }
 
-  if (load_file_data(file_name, &data, &size) == FAILED) {
+  if (load_file_data(file_name, &data, &size, lib_name) == FAILED) {
     free(name);
     free(o);
     return FAILED;
@@ -134,14 +134,17 @@ int load_file(char *file_name) {
 }
 
 
-int load_file_data(char *file_name, unsigned char **data, int *size) {
+int load_file_data(char *file_name, unsigned char **data, int *size, char *lib_name) {
 
   FILE *fop;
 
 
   fop = fopen(file_name, "rb");
   if (fop == NULL) {
-    fprintf(stderr, "LOAD_FILE_DATA: Could not open file \"%s\".\n", file_name);
+    if (lib_name)
+      fprintf(stderr, "LOAD_FILE_DATA: Could not open library \"%s\".\n", lib_name);
+    else
+      fprintf(stderr, "LOAD_FILE_DATA: Could not open file \"%s\".\n", file_name);
     return FAILED;
   }
 

--- a/wlalink/files.c
+++ b/wlalink/files.c
@@ -25,7 +25,7 @@ int load_objects(char *argv[], int argc) {
   int i;
 
 
-  for (i = total_flags + 1; i < argc - 1 ; i++) {
+  for (i = total_flags; i < argc - 1 ; i++) {
     if (load_file(argv[i]) == FAILED) return FAILED;
   }
 
@@ -51,19 +51,19 @@ int load_library(char *argv, int contains_flag) {
   fop = fopen(argv, "rb");
 
   if (fop == NULL) {
-	  /* append .lib extension if not found */
+      /* append .lib extension if not found */
      sprintf(tmp_name, "%s.lib", argv);
      fop = fopen(tmp_name, "rb");
 
      if (fop == NULL && use_libdir == YES) {
-	   /* try the lib dir if specified and not found */
+       /* try the lib dir if specified and not found */
        sprintf(tmp_name, "%s%s", ext_libdir, argv);
        fop = fopen(tmp_name, "rb");
 
        if (fop == NULL)
-		 /* append .lib extension if not found */
+         /* append .lib extension if not found */
          sprintf(tmp_name, "%s%s.lib", ext_libdir, argv);
-	 }
+     }
   }
 
   fclose(fop);

--- a/wlalink/files.h
+++ b/wlalink/files.h
@@ -2,8 +2,9 @@
 #ifndef _FILES_H
 #define _FILES_H
 
-int load_files(char *argv[], int argc);
-int load_file(char *fn, int bank, int slot, int base, int base_defined);
+int load_objects(char *argv[], int argc);
+int load_library(char *argv, int contains_flag);
+int load_file(char *fn);
 int load_file_data(char *fn, unsigned char **da, int *size);
 char *get_file_name(int id);
 char *get_source_file_name(int file_id, int source_id);

--- a/wlalink/files.h
+++ b/wlalink/files.h
@@ -4,8 +4,8 @@
 
 int load_objects(char *argv[], int argc);
 int load_library(char *argv, int contains_flag);
-int load_file(char *fn);
-int load_file_data(char *fn, unsigned char **da, int *size);
+int load_file(char *fn, char *lib_name);
+int load_file_data(char *fn, unsigned char **da, int *size, char *lib_name);
 char *get_file_name(int id);
 char *get_source_file_name(int file_id, int source_id);
 

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -44,7 +44,7 @@ int file_header_size, file_footer_size, *banksizes = NULL, *bankaddress = NULL;
 int output_mode = OUTPUT_ROM, discard_unreferenced_sections = OFF, use_libdir = NO;
 int program_start, program_end, sms_checksum, smstag_defined = 0, snes_rom_mode = SNES_ROM_MODE_LOROM, snes_rom_speed = SNES_ROM_SPEED_SLOWROM;
 int gb_checksum, gb_complement_check, snes_checksum, cpu_65816 = 0, snes_mode = 0;
-int listfile_data = NO, smc_status = 0, snes_sramsize = 0, total_flags;
+int listfile_data = NO, smc_status = 0, snes_sramsize = 0, total_flags, library_failed = NO;
 
 extern int emptyfill;
 char ext_libdir[MAX_NAME_LENGTH];
@@ -158,6 +158,9 @@ int main(int argc, char *argv[]) {
     x = parse_flags(argv, argc);
   else
     x = FAILED;
+
+  if (library_failed == YES)
+    return 0;
 
   if (x == FAILED) {
     printf("\nWLALINK GB-Z80/Z80/6502/65C02/6510/65816/HUC6280/SPC-700 WLA Macro Assembler Linker v5.8b\n");
@@ -684,7 +687,10 @@ int parse_flags(char **flags, int flagc) {
     else if (!strcmp(flags[total_flags], "-l")) {
       if (total_flags + 1 < flagc) {
         /* get arg */
-        load_library(flags[total_flags+1], NO);
+        if (load_library(flags[total_flags+1], NO) == FAILED) {
+          library_failed = YES;
+		  return FAILED;
+        }
       }
       else
         return FAILED;
@@ -718,7 +724,10 @@ int parse_flags(char **flags, int flagc) {
       /* legacy support? */
       if (strncmp(flags[total_flags], "-l", 2) == 0) {
         /* old load library */
-        load_library(flags[total_flags], YES);
+        if (load_library(flags[total_flags], YES) == FAILED) {
+          library_failed = YES;
+		  return FAILED;
+        }
       }
       else if (strncmp(flags[total_flags], "-L", 2) == 0) {
         /* old library directory */

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -684,8 +684,7 @@ int parse_flags(char **flags, int flagc) {
     else if (!strcmp(flags[total_flags], "-l")) {
       if (total_flags + 1 < flagc) {
         /* get arg */
-        if (load_library(flags[total_flags+1], NO) == FAILED)
-          return FAILED;
+        load_library(flags[total_flags+1], NO);
       }
       else
         return FAILED;
@@ -719,8 +718,7 @@ int parse_flags(char **flags, int flagc) {
       /* legacy support? */
       if (strncmp(flags[total_flags], "-l", 2) == 0) {
         /* old load library */
-        if (load_library(flags[total_flags], YES) == FAILED)
-          return FAILED;
+        load_library(flags[total_flags], YES);
       }
       else if (strncmp(flags[total_flags], "-L", 2) == 0) {
         /* old library directory */

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -44,7 +44,7 @@ int file_header_size, file_footer_size, *banksizes = NULL, *bankaddress = NULL;
 int output_mode = OUTPUT_ROM, discard_unreferenced_sections = OFF, use_libdir = NO;
 int program_start, program_end, sms_checksum, smstag_defined = 0, snes_rom_mode = SNES_ROM_MODE_LOROM, snes_rom_speed = SNES_ROM_SPEED_SLOWROM;
 int gb_checksum, gb_complement_check, snes_checksum, cpu_65816 = 0, snes_mode = 0;
-int listfile_data = NO, smc_status = 0, snes_sramsize = 0, total_flags = 0;
+int listfile_data = NO, smc_status = 0, snes_sramsize = 0, total_flags;
 
 extern int emptyfill;
 char ext_libdir[MAX_NAME_LENGTH];
@@ -171,10 +171,10 @@ int main(int argc, char *argv[]) {
     printf("-s  Write also a NO$GMB symbol file\n");
     printf("-S  Write also a WLA symbol file\n");
     printf("-v  Verbose messages\n");
-	printf("-l  LIBNAME\n");
-	printf("    Search for library LIBNAME\n");
+    printf("-l  LIBNAME\n");
+    printf("    Search for library LIBNAME\n");
     printf("-L  DIRECTORY\n");
-	printf("    Add DIRECTORY to library search path\n\n");
+    printf("    Add DIRECTORY to library search path\n\n");
     return 0;
   }
 
@@ -666,84 +666,73 @@ void procedures_at_exit(void) {
 int parse_flags(char **flags, int flagc) {
 
   int output_mode_defined = 0;
-  int count = 1;
+  total_flags = 1;
   
   while (1) {
-    if (!strcmp(flags[count], "-b")) {
+    if (!strcmp(flags[total_flags], "-b")) {
       if (output_mode_defined == 1)
 	return FAILED;
       output_mode_defined++;
       output_mode = OUTPUT_PRG;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-r")) {
+    else if (!strcmp(flags[total_flags], "-r")) {
       if (output_mode_defined == 1)
 	return FAILED;
       output_mode_defined++;
       output_mode = OUTPUT_ROM;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-l")) {
-      if (count + 1 < flagc) {
+    else if (!strcmp(flags[total_flags], "-l")) {
+      if (total_flags + 1 < flagc) {
         /* get arg */
-        if (load_library(flags[count+1], NO) == FAILED)
+        if (load_library(flags[total_flags+1], NO) == FAILED)
           return FAILED;
       }
       else
         return FAILED;
-      count++;
       total_flags++;
     }
-    else if (!strcmp(flags[count], "-L")) {
-      if (count + 1 < flagc) {
+    else if (!strcmp(flags[total_flags], "-L")) {
+      if (total_flags + 1 < flagc) {
         /* get arg */
-        parse_and_set_libdir(flags[count+1], NO);
+        parse_and_set_libdir(flags[total_flags+1], NO);
       }
       else
         return FAILED;
-      count++;
       total_flags++;
     }
-    else if (!strcmp(flags[count], "-i")) {
+    else if (!strcmp(flags[total_flags], "-i")) {
       listfile_data = YES;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-v")) {
+    else if (!strcmp(flags[total_flags], "-v")) {
       verbose_mode = ON;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-s")) {
+    else if (!strcmp(flags[total_flags], "-s")) {
       symbol_mode = SYMBOL_MODE_NOCA5H;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-S")) {
+    else if (!strcmp(flags[total_flags], "-S")) {
       symbol_mode = SYMBOL_MODE_WLA;
-      total_flags++;
     }
-    else if (!strcmp(flags[count], "-d")) {
+    else if (!strcmp(flags[total_flags], "-d")) {
       discard_unreferenced_sections = ON;
-      total_flags++;
     }
     else {
       /* legacy support? */
-      if (strncmp(flags[count], "-l", 2) == 0) {
+      if (strncmp(flags[total_flags], "-l", 2) == 0) {
         /* old load library */
-        if (load_library(flags[count], YES) == FAILED)
+        if (load_library(flags[total_flags], YES) == FAILED)
           return FAILED;
-        total_flags++;
       }
-      else if (strncmp(flags[count], "-L", 2) == 0) {
+      else if (strncmp(flags[total_flags], "-L", 2) == 0) {
         /* old library directory */
-        parse_and_set_libdir(flags[count], YES);
-        total_flags++;
+        parse_and_set_libdir(flags[total_flags], YES);
       }
       /* reached object file? */
       else
         break;
     }
-    count++;
+    total_flags++;
   }
-  
+
   return SUCCEEDED;
 }
 

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -689,7 +689,7 @@ int parse_flags(char **flags, int flagc) {
         /* get arg */
         if (load_library(flags[total_flags+1], NO) == FAILED) {
           library_failed = YES;
-		  return FAILED;
+          return FAILED;
         }
       }
       else
@@ -726,7 +726,7 @@ int parse_flags(char **flags, int flagc) {
         /* old load library */
         if (load_library(flags[total_flags], YES) == FAILED) {
           library_failed = YES;
-		  return FAILED;
+          return FAILED;
         }
       }
       else if (strncmp(flags[total_flags], "-L", 2) == 0) {


### PR DESCRIPTION
The new command line works as follows:
wlalink [OPTIONS] \<OBJECT FILES\> \<OUTPUT FILE\>
Libraries are specified just like in ANSI-C. That is, -llibname.
Note that because you can no longer specify the library bank/slot, it defaults to bank 0 slot 0. If that is occupied by rom data, you must write the library's section as SUPERFREE to allow it to be placed in the first free section. The working directory is first searched, then the lib directory. In each case ".lib" will be appended if the library is not found. This lets you specify custom extensions, or use no extension to save time :D

Examples:
wlalink -v -L./lib -ldebug -lc -lm main.o graphics.o sprites.o MyGame.nes
wlalink -S -v -Lsdk/lib -ldrawSprites.lib -ltest.obj game.o Output.bin

TODO:
- still need to remove any existing linkfile/header/footer code. or add commands such as -h "header.bin" -f "footer.bin"
- more testing, I only tested it with my project and a sample library with no problems.
- update readme
- also the parse_flags needs a redundancy check