### PR TITLE
Add a .ROMGBCONLY directive

### DIFF
--- a/README
+++ b/README
@@ -155,6 +155,7 @@ Group 2:
 [GB ] .RAMSIZE 0
 [GB ] .ROMDMG
 [GB ] .ROMGBC
+[GB ] .ROMGBCONLY
 [GB ] .ROMSGB
 [658] .SLOWROM
 [658] .SMC
@@ -571,16 +572,18 @@ This is not a compulsory directive.
 ---------
 
 This begins the GB header definition, and automatically defines
-.COMPUTEGBCHECKSUM. From here you may define any of the following:
+.COMPUTEGBCHECKSUM. End the header definition with .ENDGB. Here's an example:
 
-NAME "TANKBOMBPANIC" - identical to a freestanding .NAME.
-LICENSEECODEOLD $34  - identical to a freestanding .LICENSEECODEOLD.
-LICENSEECODENEW "HI" - identical to a freestanding .LICENSEECODENEW.
-CARTRIDGETYPE $00    - identical to a freestanding .CARTRIDGETYPE.
-RAMSIZE $09          - identical to a freestanding .RAMSIZE.
-COUNTRYCODE $01      - identical to a freestanding .COUNTRYCODE.
-DESTINATIONCODE $01  - identical to a freestanding .DESTINATIONCODE.
-NINTENDOLOGO         - identical to a freestanding .NINTENDOLOGO.
+.GBHEADER
+        NAME "TANKBOMBPANIC" ; identical to a freestanding .NAME.
+        LICENSEECODEOLD $34  ; identical to a freestanding .LICENSEECODEOLD.
+        LICENSEECODENEW "HI" ; identical to a freestanding .LICENSEECODENEW.
+        CARTRIDGETYPE $00    ; identical to a freestanding .CARTRIDGETYPE.
+        RAMSIZE $09          ; identical to a freestanding .RAMSIZE.
+        COUNTRYCODE $01      ; identical to a freestanding .COUNTRYCODE.
+        DESTINATIONCODE $01  ; identical to a freestanding .DESTINATIONCODE.
+        NINTENDOLOGO         ; identical to a freestanding .NINTENDOLOGO.
+.ENDGB
 
 This is not a compulsory directive.
 
@@ -2304,8 +2307,19 @@ required to terminate it.
 .ROMGBC
 -------
 
+Inserts data into the specific ROM location to mark the ROM as a dual-mode ROM
+($80 -> $0143, so ROM name is max. 15 characters long). It will run in either
+DMG or GBC mode.
+
+This is not a compulsory directive.
+
+-----------
+.ROMGBCONLY
+-----------
+
 Inserts data into the specific ROM location to mark the ROM as a Gameboy Color
-ROM ($C0 -> $0143, so ROM name is max. 15 characters long).
+ROM ($C0 -> $0143, so ROM name is max. 15 characters long). It will only run in
+GBC mode.
 
 This is not a compulsory directive.
 
@@ -2314,7 +2328,7 @@ This is not a compulsory directive.
 -------
 
 Inserts data into the specific ROM location to mark the ROM as a DMG
-(Gameboy) ROM ($00 -> $0146).
+(Gameboy) ROM ($00 -> $0146). It will only run in DMG mode.
 
 This is not a compulsory directive. .ROMDMG cannot be used with .ROMSGB.
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -4404,11 +4404,15 @@ int parse_directive(void) {
     while ((ind = get_next_token()) == SUCCEEDED) {
       if (strcaselesscmp(tmp, ".ENDGB") == 0)
         break;
-      else if (strcaselesscmp(cp, "NINTENDOLOGO") == 0)
+      else if (strcaselesscmp(tmp, "NINTENDOLOGO") == 0)
         nintendologo_defined++;
       else if (strcaselesscmp(tmp, "ROMDMG") == 0) {
-        if (romgbc != 0) {
+        if (romgbc == 1) {
 	  print_error(".ROMGBC was defined prior to .ROMDMG.\n", ERROR_DIR);
+          return FAILED;
+        }
+        else if (romgbc == 2) {
+	  print_error(".ROMGBCONLY was defined prior to .ROMDMG.\n", ERROR_DIR);
           return FAILED;
         }
         else if (romsgb != 0) {
@@ -4422,7 +4426,22 @@ int parse_directive(void) {
 	  print_error(".ROMDMG was defined prior to .ROMGBC.\n", ERROR_DIR);
           return FAILED;
         }
-        romgbc++;
+        else if (romgbc == 2) {
+	  print_error(".ROMGBCONLY was defined prior to .ROMGBC.\n", ERROR_DIR);
+          return FAILED;
+        }
+        romgbc = 1;
+      }
+      else if (strcaselesscmp(tmp, "ROMGBCONLY") == 0) {
+        if (romdmg != 0) {
+	  print_error(".ROMDMG was defined prior to .ROMGBCONLY.\n", ERROR_DIR);
+          return FAILED;
+        }
+        else if (romgbc == 1) {
+	  print_error(".ROMGBC was defined prior to .ROMGBCONLY.\n", ERROR_DIR);
+          return FAILED;
+        }
+        romgbc = 2;
       }
       else if (strcaselesscmp(tmp, "ROMSGB") == 0) {
         if (romdmg != 0) {
@@ -5586,11 +5605,35 @@ int parse_directive(void) {
     no_library_files(".ROMGBC");
     
     if (romdmg != 0) {
-      print_error("ROMDMG was defined prior to .ROMGBC.\n", ERROR_DIR);
+      print_error(".ROMDMG was defined prior to .ROMGBC.\n", ERROR_DIR);
+      return FAILED;
+    }
+    else if (romgbc == 2) {
+      print_error(".ROMGBCONLY was defined prior to .ROMGBC.\n", ERROR_DIR);
       return FAILED;
     }
 
-    romgbc++;
+    romgbc = 1;
+
+    return SUCCEEDED;
+  }
+
+  /* ROMGBCONLY */
+
+  if (strcaselesscmp(cp, "ROMGBCONLY") == 0) {
+
+    no_library_files(".ROMGBCONLY");
+
+    if (romdmg != 0) {
+      print_error(".ROMDMG was defined prior to .ROMGBCONLY.\n", ERROR_DIR);
+      return FAILED;
+    }
+    else if (romgbc == 1) {
+      print_error(".ROMGBC was defined prior to .ROMGBCONLY.\n", ERROR_DIR);
+      return FAILED;
+    }
+
+    romgbc = 2;
 
     return SUCCEEDED;
   }
@@ -5600,8 +5643,12 @@ int parse_directive(void) {
   if (strcaselesscmp(cp, "ROMDMG") == 0) {
     no_library_files(".ROMDMG");
     
-    if (romgbc != 0) {
+    if (romgbc == 1) {
       print_error(".ROMGBC was defined prior to .ROMDMG.\n", ERROR_DIR);
+      return FAILED;
+    }
+    else if (romgbc == 2) {
+      print_error(".ROMGBCONLY was defined prior to .ROMDMG.\n", ERROR_DIR);
       return FAILED;
     }
     else if (romsgb != 0) {

--- a/pass_2.c
+++ b/pass_2.c
@@ -317,8 +317,11 @@ int pass_2(void) {
       }
     }
     
-    if (romgbc != 0)
-      mem_insert_absolute(323, 128);
+    if (romgbc == 1)
+      mem_insert_absolute(323, 0x80);
+    else if (romgbc == 2)
+      mem_insert_absolute(323, 0xc0);
+
     if (romdmg != 0)
       mem_insert_absolute(326, 0);
     if (romsgb != 0)


### PR DESCRIPTION
The .ROMGBC directive writes $80 to $143 in the cartridge header, contrary to what the readme said. This indicates that it's a "dual-mode" game, which can run in either GBC or DMG mode.

The new .ROMGBCONLY directive writes $c0 to $143, indicating that it can ONLY run in gbc mode.

I also added this to the .gbheader structure, although I'm not entirely convinced that other aspects of the gbheader are working correctly... this commit also fixes "nintendologo" so that it works with .gbheaders, though there may be other issues.