### PR TITLE
Avoid OOB pointer dereference in the preprocessor

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -666,7 +666,7 @@ int preprocess_file(char *input, char *input_end, char *out_buffer, int *out_siz
       /* take away white space from the end of the line */
       input++;
       output--;
-      for ( ; *output == ' '; output--)
+      for ( ; output > out_buffer && *output == ' '; output--)
 	;
       output++;
       *output = 0x0A;


### PR DESCRIPTION
A similar check exists in all the other places where the output buffer
pointer is decremented.

Fixes #131