### PR TITLE
Make _sizeof labels choose the label hashmaps more wisely.

### DIFF
--- a/README
+++ b/README
@@ -2717,13 +2717,25 @@ calculations and sees only the preprocessed output of WLA):
                 ; a macro).
 
 WLALINK will also generate _sizeof_[label] defines that measure the distance
-between two consecutive labels. Here is an example:
+between two consecutive labels. These labels have the same scope as the labels
+they describe. Here is an example:
 
 Label1:
    .db 1, 2, 3, 4
 Label2:
 
 In this case you'll get a definition _sizeof_Label1 that will have value 4.
+
+WLA will skip over any child labels when calculating _sizeof. So, in this
+example:
+
+Label1:
+   .db 1, 2
+@child:
+   .db 3, 4
+Label2:
+
+The value of "_sizeof_Label1" will still have a value of 4.
 
 
 3.4. Number Types

--- a/examples/gb-z80/namespace_test/main.s
+++ b/examples/gb-z80/namespace_test/main.s
@@ -99,10 +99,14 @@ parent2:
 	push hl
 	ld hl,data
 
-	; Test the value of the sizeof label
+	; Test the values of the sizeof labels
 	ldi a,(hl)
 -
 	cp 6
+	jr nz,-
+	ldi a,(hl)
+-
+ 	cp 4
 	jr nz,-
 
 	; Make sure the arithmetic worked (if not it'll jump to some garbage place)
@@ -122,7 +126,11 @@ _LOOP:	LD	($FF00+R_BGP), A	;background palette.
 
 data:
 	.db _sizeof__LOOP ; Should be 6
+	.db shared._sizeof_sharedEntry ; Should be 4
 	.dw s3.func3 + 20 ; Test arithmetic on namespaces
+
+	; Uncomment for error (since _globalFunc is a local name)
+	;.db shared._sizeof__globalFunc
 
 
 .ENDS
@@ -137,6 +145,8 @@ sharedEntry:
 
 _globalFunc: ; Should not be called
 	jr _globalFunc
+
+	.db _sizeof__globalFunc
 .ENDS
 
 _globalFunc:

--- a/examples/gb-z80/namespace_test/main.s
+++ b/examples/gb-z80/namespace_test/main.s
@@ -122,10 +122,14 @@ parent2:
 
 _LOOP:	LD	($FF00+R_BGP), A	;background palette.
 	INC	A 
+
+@child: ; When calculating "sizeof" for _LOOP, it should skip over these child labels
+@@child:
+
 	JP	_LOOP
 
 data:
-	.db _sizeof__LOOP ; Should be 6
+	.db _sizeof__LOOP ; Should be 6 (skips over child label)
 	.db shared._sizeof_sharedEntry ; Should be 4
 	.dw s3.func3 + 20 ; Test arithmetic on namespaces
 

--- a/examples/gb-z80/namespace_test/main.s
+++ b/examples/gb-z80/namespace_test/main.s
@@ -87,9 +87,8 @@ parent:
 	.db <@a+1
 
 parent2:
-; Give this one more character to get an error (will be too long when turned
-; into "parent2@reallyreally...longname".
-@reallyreallyreallyreallyreallyreallyreallyreallylongnam:
+; This is higher than the old limit of ~64 characters, but now the limit is 255
+@reallyreallyreallyreallyreallyreallyreallyreallylongname:
 
 @continue:
 @@continueChild:
@@ -99,6 +98,14 @@ parent2:
 	ld hl,_LOOP
 	push hl
 	ld hl,data
+
+	; Test the value of the sizeof label
+	ldi a,(hl)
+-
+	cp 6
+	jr nz,-
+
+	; Make sure the arithmetic worked (if not it'll jump to some garbage place)
 	ldi a,(hl)
 	ld h,(hl)
 	ld l,a
@@ -114,6 +121,7 @@ _LOOP:	LD	($FF00+R_BGP), A	;background palette.
 	JP	_LOOP
 
 data:
+	.db _sizeof__LOOP ; Should be 6
 	.dw s3.func3 + 20 ; Test arithmetic on namespaces
 
 

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -556,25 +556,16 @@ int try_put_label(map_t map, struct label *l) {
 }
 
 
+/* Determines the section for each label, and calls "insert_label_into_maps" for each. */
 int fix_label_sections(void) {
 
   struct section *s;
   struct label *l;
 
-  
   l = labels_first;
   while (l != NULL) {
-    int put_in_global = 1;
-    int put_in_anything = 1;
-
-    if (l->status == LABEL_STATUS_SYMBOL
-        || l->status == LABEL_STATUS_BREAKPOINT
-        || is_label_anonymous(l->name) == SUCCEEDED) {
-      /* don't put anonymous labels, breakpoints, or symbols into any maps */
-      put_in_anything = 0;
-    }
-
     if (l->section_status == ON) {
+      /* Search for the label's section */
       s = sec_first;
       while (s != NULL) {
         if (s->id == l->section) {
@@ -586,37 +577,60 @@ int fix_label_sections(void) {
 
       if (s == NULL) {
         fprintf(stderr, "FIX_LABEL_SECTIONS: Internal error: couldn't find section %d for label \"%s\".\n",
-		l->section, l->name);
+                l->section, l->name);
         return FAILED;
-      }
-
-      if (put_in_anything) {
-        /* put label into section's label map */
-        if (try_put_label(s->label_map, l) == FAILED)
-          return FAILED;
-
-        if (l->name[0] == '_')
-          put_in_global = 0;
-
-        /* put label into section's namespace's label map, if it's not a local label */
-        if (s->nspace != NULL && l->name[0] != '_') {
-          if (try_put_label(s->nspace->label_map, l) == FAILED)
-            return FAILED;
-          put_in_global = 0;
-        }
       }
     }
 
-    /* put the label into the global namespace */
-    if (put_in_anything && put_in_global) {
-      if (try_put_label(global_unique_label_map, l) == FAILED)
-        return FAILED;
-    }
+    insert_label_into_maps(l);
 
     l = l->next;
   }
 
   return SUCCEEDED;
+}
+
+
+
+/* Determines which hashmaps are relevant for the label, and adds it to them. */
+int insert_label_into_maps(struct label* l) {
+  int put_in_global = 1;
+  int put_in_anything = 1;
+
+  if (l->status == LABEL_STATUS_SYMBOL
+      || l->status == LABEL_STATUS_BREAKPOINT
+      || is_label_anonymous(l->name) == SUCCEEDED) {
+    /* don't put anonymous labels, breakpoints, or symbols into any maps */
+    put_in_anything = 0;
+  }
+
+  if (l->section_status == ON) {
+    struct section *s;
+    
+    s = l->section_struct;
+
+    if (put_in_anything) {
+      /* put label into section's label map */
+      if (try_put_label(s->label_map, l) == FAILED)
+        return FAILED;
+
+      if (l->name[0] == '_')
+        put_in_global = 0;
+
+      /* put label into section's namespace's label map, if it's not a local label */
+      if (s->nspace != NULL && l->name[0] != '_') {
+        if (try_put_label(s->nspace->label_map, l) == FAILED)
+          return FAILED;
+        put_in_global = 0;
+      }
+    }
+  }
+
+  /* put the label into the global namespace */
+  if (put_in_anything && put_in_global) {
+    if (try_put_label(global_unique_label_map, l) == FAILED)
+      return FAILED;
+  }
 }
 
 
@@ -1886,6 +1900,8 @@ int generate_sizeof_label_definitions(void) {
   */
   
   for (j = 0; j < labelsN-1; j++) {
+    int put_in_global = 1;
+
     if (labels[j]->section != labels[j+1]->section)
       continue;
     
@@ -1896,21 +1912,29 @@ int generate_sizeof_label_definitions(void) {
       return FAILED;
     }
 
+    if (strlen(labels[j]->name)+8 > MAX_NAME_LENGTH) {
+      fprintf(stderr, "GENERATE_SIZEOF_LABEL_DEFINITIONS: Expanded label name \"_sizeof_%s\" is %d bytes too large.\n",
+              labels[j]->name,
+              strlen(labels[j]->name)-MAX_NAME_LENGTH+8);
+      free(labels);
+      return FAILED;
+    }
+
     sprintf(l->name, "_sizeof_%s", labels[j]->name);
     l->status = LABEL_STATUS_DEFINE;
     l->address = labels[j+1]->rom_address - labels[j]->rom_address;
     l->base = 0;
     l->file_id = labels[j]->file_id;
-    l->section_status = OFF;
-    l->section_struct = NULL;
-	
-    add_label(l);
 
-    /* put the label into the global namespace */
-    if (try_put_label(global_unique_label_map, l) == FAILED) {
+    l->section_status = labels[j]->section_status;
+    l->section_struct = labels[j]->section_struct;
+    l->section        = labels[j]->section;
+
+    if (insert_label_into_maps(l) == FAILED) {
       free(labels);
       return FAILED;
     }
+    add_label(l);
   }
   
   free(labels);

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -1866,7 +1866,7 @@ static int _labels_sort(const void *a, const void *b) {
 
 int generate_sizeof_label_definitions(void) {
 
-  struct label *l, **labels = NULL;
+  struct label *l, *lastL, **labels = NULL;
   int labelsN = 0, j;
 
 
@@ -1875,10 +1875,17 @@ int generate_sizeof_label_definitions(void) {
   
   /* generate _sizeof_[label] definitions */
   l = labels_first;
+  lastL = NULL;
   while (l != NULL) {
-    /* skip anonymous labels */
-    if (l->status == LABEL_STATUS_LABEL && is_label_anonymous(l->name) != SUCCEEDED)
+    /* skip anonymous labels & child labels */
+    if (l->status == LABEL_STATUS_LABEL && is_label_anonymous(l->name) != SUCCEEDED
+        && (lastL == NULL
+            || !(strncmp(lastL->name, l->name, strlen(lastL->name)) == 0
+                && l->name[strlen(lastL->name)] == '@'))) {
       labelsN++;
+      lastL = l;
+    }
+
     l = l->next;
   }
 
@@ -1893,9 +1900,17 @@ int generate_sizeof_label_definitions(void) {
   
   j = 0;
   l = labels_first;
+  lastL = NULL;
   while (l != NULL) {
-    if (l->status == LABEL_STATUS_LABEL && is_label_anonymous(l->name) != SUCCEEDED)
+    /* skip anonymous labels & child labels */
+    if (l->status == LABEL_STATUS_LABEL && is_label_anonymous(l->name) != SUCCEEDED
+        && (lastL == NULL
+            || !(strncmp(lastL->name, l->name, strlen(lastL->name)) == 0
+                && l->name[strlen(lastL->name)] == '@'))) {
       labels[j++] = l;
+      lastL = l;
+    }
+
     l = l->next;
   }
       

--- a/wlalink/write.h
+++ b/wlalink/write.h
@@ -4,6 +4,7 @@
 
 int fix_references(void);
 int fix_label_sections(void);
+int insert_label_into_maps(struct label *l, int is_sizeof);
 int fix_label_addresses(void);
 int transform_stack_definitions(void);
 int insert_sections(void);


### PR DESCRIPTION
This should fix issues with multiple labels of the same name across different sections. I refactored out the code that decides which hashmap a label goes into, to use for the _sizeof labels.

_sizeof labels will inherit the "locality" of the base label they came from. So, despite starting with an underscore, they won't always be local. (And they won't always be global like before.) I put a few tests in my "namespaces" example.

This doesn't do anything with the "@" labels, which as @maxim-zhao mentioned, maybe should behave a bit differently, though I don't really care much about that... =P

This is a followup to #136.