### PR TITLE
Off-by-1 error with nintendo logo

### DIFF
--- a/pass_2.c
+++ b/pass_2.c
@@ -332,7 +332,7 @@ int pass_2(void) {
       int nl1 = 0x104;
       unsigned int nl2 = 0;
       
-      while (nl2 <= sizeof(nintendo_logo_dat)) {
+      while (nl2 < sizeof(nintendo_logo_dat)) {
         mem_insert_absolute(nl1, nintendo_logo_dat[nl2]);
         nl1++;
         nl2++;


### PR DESCRIPTION
I was getting a "data being overwritten" warning when I tried defining the "cartridge title" manually, which comes directly after the nintendo logo...

A harmless bug, at any rate.