### PR TITLE
Allow the use of ".IF" directives within enums and ramsections

### DIFF
--- a/README
+++ b/README
@@ -1872,6 +1872,8 @@ And this is what is generated:
 This way you can generate a 16-bit variable address along with pointers
 to its parts.
 
+You can use all ".IF" and ".ELSE" directives within an enum.
+
 If you want more flexible variable positioning, take a look at
 .RAMSECTIONs.
 
@@ -2328,6 +2330,8 @@ If no other RAM sections are used, then this is what you will get:
 
 BANK in .RAMSECTION is optional so you can leave it away if you
 don't switch RAM banks, or the target doesn't have them.
+
+You can use all ".IF" and ".ELSE" directives within an enum.
 
 This is not a compulsory directive.
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -1325,10 +1325,8 @@ int parse_enum_token() {
       }
     }
   }
-  else if (in_enum && tmp[0] == '.' && strcaselesscmp(tmp, ".ENDE") != 0)
-    ;
-  else if (in_ramsection && tmp[0] == '.' && strcaselesscmp(tmp, ".ENDS") != 0)
-    ;
+  else if (strcaselesscmp(tmp, ".db") == 0 || strcaselesscmp(tmp, ".dw") == 0)
+    ; /* Don't do anything for "dotted" versions */
   else {
     if (in_enum)
       sprintf(emsg, "Unexpected symbol \"%s\" in .ENUM.\n", tmp);

--- a/pass_1.h
+++ b/pass_1.h
@@ -9,6 +9,7 @@ int export_a_definition(char *name);
 int redefine(char *name, double value, char *string, int type, int size);
 int undefine(char *name);
 int parse_directive(void);
+int parse_if_directive(void);
 int find_next_point(char *name);
 int get_new_definition_data(int *b, char *c, int *size, double *data);
 int localize_path(char *path);


### PR DESCRIPTION
As usual, I did this because I desperately needed this feature. I'm integrating two games, Oracle of Ages and Seasons into the same codebase, and I absolutely need to define RAM conditionally.

This was easier to do than I thought it would be. Enum and ramsection code has been moved into a separate function, moved outside of the "parse_directive" function to be part of the "evaluate_token" loop. This has the added benefit of refactoring the very similar enum and ramsection code to be together.

The "IF" directives have been moved into the "parse_if_directive" function, which is like "parse_directive" but only for those IF directives. It's reused by the enum/ramsection code.

Looking back, I probably could have done this without refactoring the enum and ramsection stuff out of parse_directive, but... eh.

In addition, I noticed that the code was checking for literally any string starting with a dot, and treating that as a "non-advancing define". That... felt really wrong. I've changed it to only check for ".db" and ".dw". But ".dsb", ".dsw", and ".instanceof" weren't working anyway because it wasn't checking for the parameters that come after. So, bug #30 still applies.

I did this without consulting anyone, so please point out if I did this in a non-preferred way or something.