### PR TITLE
Allow .IF directives on all other directives with custom parsers

### DIFF
--- a/README
+++ b/README
@@ -1598,8 +1598,9 @@ The following operators are supported:
 == - equals to
 != - doesn't equal to
 
-All IF (yes, including .IFDEF, .IFNDEF, etc) directives can be
-nested.
+All IF directives (yes, including .IFDEF, .IFNDEF, etc) can be
+nested. They can also be used within ENUMs, RAMSECTIONs, STRUCTs,
+ROMBANKMAPs, and most other directives that occupy multiple lines.
 
 This is not a compulsory directive.
 
@@ -1871,8 +1872,6 @@ And this is what is generated:
 
 This way you can generate a 16-bit variable address along with pointers
 to its parts.
-
-You can use all ".IF" and ".ELSE" directives within an enum.
 
 If you want more flexible variable positioning, take a look at
 .RAMSECTIONs.
@@ -2330,8 +2329,6 @@ If no other RAM sections are used, then this is what you will get:
 
 BANK in .RAMSECTION is optional so you can leave it away if you
 don't switch RAM banks, or the target doesn't have them.
-
-You can use all ".IF" and ".ELSE" directives within an enum.
 
 This is not a compulsory directive.
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -1094,7 +1094,7 @@ void next_line(void) {
 }
 
 
-/* wither "in_enum" or "in_ramsection" should be true when this is called. */
+/* either "in_enum" or "in_ramsection" should be true when this is called. */
 int parse_enum_token(void) {
 
   char tmpname[MAX_NAME_LENGTH];
@@ -1678,6 +1678,16 @@ int parse_directive(void) {
 
     /* read the entries */
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDA") == 0)
         break;
       else if (strcaselesscmp(tmp, "MAP") == 0) {
@@ -2403,6 +2413,16 @@ int parse_directive(void) {
       if (get_next_token() == FAILED)
         return FAILED;
 
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       /* end of STRUCT? */
       if (strcaselesscmp(tmp, ".ENDST") == 0) {
         /* create the SIZEOF-definition */
@@ -2573,7 +2593,7 @@ int parse_directive(void) {
             return FAILED;
          }
       }
-      else if (tmp[0] == '.') {
+      else if (strcaselesscmp(tmp, ".db") == 0 || strcaselesscmp(tmp, ".dw") == 0) {
         si->size = 0;
         continue;
       }
@@ -3548,6 +3568,16 @@ int parse_directive(void) {
     if (rombankmap_defined != 0 || rombanks_defined != 0) {
       o = 0;
       while ((ind = get_next_token()) == SUCCEEDED) {
+        /* .IF directive? */
+        if (tmp[0] == '.') {
+          q = parse_if_directive();
+          if (q == FAILED)
+            return FAILED;
+          else if (q == SUCCEEDED)
+            continue;
+          /* else q == -1, continue executing below */
+        }
+
         if (strcaselesscmp(tmp, ".ENDRO") == 0) {
           break;
         }
@@ -3638,6 +3668,16 @@ int parse_directive(void) {
     else {
       o = 0;
       while ((ind = get_next_token()) == SUCCEEDED) {
+        /* .IF directive? */
+        if (tmp[0] == '.') {
+          q = parse_if_directive();
+          if (q == FAILED)
+            return FAILED;
+          else if (q == SUCCEEDED)
+            continue;
+          /* else q == -1, continue executing below */
+        }
+
         if (strcaselesscmp(tmp, ".ENDRO") == 0)
           break;
         else if (strcaselesscmp(tmp, "BANKSTOTAL") == 0) {
@@ -3805,6 +3845,16 @@ int parse_directive(void) {
       print_error("Libraries don't need .MEMORYMAP.\n", ERROR_WRN);
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDME") == 0) {
         if (defaultslot_defined == 0) {
           print_error("No DEFAULTSLOT defined.\n", ERROR_DIR);
@@ -4267,6 +4317,16 @@ int parse_directive(void) {
     }
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDGB") == 0)
         break;
       else if (strcaselesscmp(tmp, "NINTENDOLOGO") == 0)
@@ -4914,6 +4974,16 @@ int parse_directive(void) {
     }
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDSMS") == 0)
         break;
       else if (strcaselesscmp(tmp, "VERSION") == 0) {
@@ -5808,6 +5878,16 @@ int parse_directive(void) {
     }
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDSNES") == 0)
         break;
 
@@ -6083,6 +6163,16 @@ int parse_directive(void) {
     fprintf(file_out_ptr, "k%d ", active_file_info_last->line_current);
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDNATIVEVECTOR") == 0) {
         if (cop_defined == 0)
           sprintf(cop, "y%d ", 0x0000);
@@ -6287,6 +6377,16 @@ int parse_directive(void) {
     fprintf(file_out_ptr, "k%d ", active_file_info_last->line_current);
 
     while ((ind = get_next_token()) == SUCCEEDED) {
+      /* .IF directive? */
+      if (tmp[0] == '.') {
+        q = parse_if_directive();
+        if (q == FAILED)
+          return FAILED;
+        else if (q == SUCCEEDED)
+          continue;
+        /* else q == -1, continue executing below */
+      }
+
       if (strcaselesscmp(tmp, ".ENDEMUVECTOR") == 0) {
         if (cop_defined == 0)
           sprintf(cop, "y%d ", 0);


### PR DESCRIPTION
Taking @nicklausw's suggestion from #150.

Affected directives:
* GBHEADER
* SMSHEADER
* SNESEMUVECTOR
* SNESHEADER
* SNESNATIVEVECTOR
* ASCIITABLE
* MEMORYMAP
* ROMBANKMAP
* STRUCT

I haven't tested all of these, but most of the examples still work (see below...). Since it was a simple copy/paste job, I'd be surprised if any of them broke, though.

I remembered when I was going through this that STRUCT is much the same as ENUM and RAMSECTION, so I applied the same change related to dotted labels. I guess ideally I'd refactor that too, but... eh.

Another note: the enum/ramsection/struct change to dotted opcodes has caused an error in spc-700/linker_test. You could argue that the test case is broken, since it uses the enum in a way not specified in the readme...