### PR TITLE
Respect `.BASE` in more places, partial fix for #166

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -89,7 +89,7 @@
 /* O - origin              */
 /* o - absolute origin     */
 /* B - ROM bank            */
-/* b - BASE (65816)        */
+/* b - BASE                */
 /* L - label               */
 /* r - 16-bit reference    */
 /* R - 8-bit pc ref        */
@@ -607,9 +607,7 @@ struct stack {
   int bank;
   int slot;
   int relative_references;
-#ifdef W65816
   int base;
-#endif
   int section_status;
   int section_id;
   int address;

--- a/pass_3.c
+++ b/pass_3.c
@@ -448,6 +448,7 @@ int pass_3(void) {
 
 #ifdef W65816
     case 'z':
+#endif
     case 'q':
       fscanf(f_in, "%*s ");
       add += 3;
@@ -457,8 +458,6 @@ int pass_3(void) {
       fscanf(f_in, "%*d ");
       add += 3;
       continue;
-
-#endif
 
     case 'b':
       fscanf(f_in, "%d ", &base);

--- a/pass_4.c
+++ b/pass_4.c
@@ -553,7 +553,6 @@ int pass_4(void) {
 
         continue;
 
-#ifdef W65816
         /* 24BIT COMPUTATION */
 
       case 'T':
@@ -642,6 +641,7 @@ int pass_4(void) {
 
         continue;
 
+#ifdef W65816
         /* 16BIT PC RELATIVE REFERENCE */
 
       case 'M':

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -259,11 +259,9 @@ int main(int argc, char *argv[]) {
     discard_drop_labels();
   }
 
-  /* correct 65816 library section addresses */
-  if (cpu_65816 != 0) {
-    if (correct_65816_library_sections() == FAILED)
-      return 1;
-  }
+  /* correct non-zero-BASE library section addresses */
+  if (correct_65816_library_sections() == FAILED)
+    return 1;
 
   /* if ROM size < 32KBs, correct SDSC tag sections' addresses */
   if (smstag_defined != 0 && romsize < 0x8000) {

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -739,6 +739,7 @@ int fix_references(void) {
         strcpy(lt.name, &r->name[1]);
         lt.address = r->address;
         lt.bank = r->bank;
+        lt.base = 0;
         lt.section_status = OFF;
         l = &lt;
       }
@@ -754,7 +755,7 @@ int fix_references(void) {
       if (cpu_65816 != 0)
         i = get_snes_pc_bank(l) >> 16;
       else
-        i = l->bank + l->base;
+        i = l->base + l->bank;
 
       memory_file_id = r->file_id;
       memory_file_id_source = r->file_id_source;
@@ -791,6 +792,7 @@ int fix_references(void) {
         strcpy(lt.name, r->name);
         lt.address = r->address;
         lt.bank = r->bank;
+        lt.base = 0;
         lt.section_status = OFF;
         l = &lt;
       }
@@ -1649,7 +1651,7 @@ int parse_stack(struct stack *sta) {
             if (cpu_65816 != 0)
               k = get_snes_pc_bank(l) >> 16;
             else
-              k = l->bank;
+              k = l->base + l->bank;
           }
 	}
       }


### PR DESCRIPTION
24-bit label math is now (theoretically) possible outside 65816. Overriding the base for library sections is now (theoretically) possible outside 65816. `:CADDR` now gives sensible results again, instead of adding an uninitialized value. (It used to give nonsense results, but only on 65816; it was my previous universal-base efforts that expanded that bug to the other backends.)

`CADDR` still does not respect `.BASE`, but I don't see a simple way to fully handle that without breaking an on-disk format. I don't know what this project's conventions are regarding format stability, but I do know that the current behavior will only cause problems for people using `CADDR` **with** `.BASE`. At least it will now give sensible, if non-`.BASE`d, values for `:CADDR` instead of random ones...