### PR TITLE
Fix compilation with special section and buffer overflow for \xXX strings

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -1589,7 +1589,7 @@ int parse_directive(void) {
 	  }
 	  /* handle '\x' */
 	  else if (label[o] == '\\' && label[o + 1] == 'x') {
-	    char tmp_a[2], *tmp_b;
+	    char tmp_a[3], *tmp_b;
 	    int tmp_c;
 	    
 	    o += 3;

--- a/wlalink/discard.c
+++ b/wlalink/discard.c
@@ -13,6 +13,7 @@
 
 extern struct reference *reference_first, *reference_last;
 extern struct section *sec_first, *sec_last;
+extern struct section *sec_hd_first;
 extern struct label *labels_first, *labels_last;
 extern struct stack *stacks_first, *stacks_last;
 
@@ -111,9 +112,15 @@ int discard_iteration(void) {
       if (r->section_status == OFF)
         s->referenced++;
       else if (r->section != s->id) {
-        ss = sec_first;
-        while (ss->id != r->section)
+        ss = sec_hd_first;
+        /* find it in special sections first */
+        while (ss != NULL && ss->id != r->section)
           ss = ss->next;
+        if (ss == NULL) {
+          ss = sec_first;
+          while (ss->id != r->section)
+            ss = ss->next;
+        }
         if (ss->alive == YES)
           s->referenced++;
       }


### PR DESCRIPTION
I'm offloading some stuff from my PR #164, starting with 2 bug fixes I encountered while testing the tests. The following are from the commits themselves.

> Fix that refs from special sections aren't found when discarding
> 
> In the z80/linker_header_test, there is a section called BANKHEADER,
> that is treated specially and put into its own list.
>
> However, when determining what section is used by the linker (so it can
> remove that section), it checks all references with each section.
> However, a reference from that special BANKHEADER section won't be found
> in the normal section list, where it looked up. And since there was an
> assumption that there is at least one reference to a section, there was
> no NULL check and it just walks past the list.
> 
> Fixed by checking the special list first.

and

> QuickFix buffer overflow for \xXX strings
> 
> You know, the \0 character also needs some space.

(Note that there is `sprintf(tmp_a, "%c%c", label[o-1], label[o]);` directly after `o += 3;` in GitHub diff)