### PR TITLE
Don't crash when trying to print ops in DEBUG binary

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -711,6 +711,8 @@ void output_assembled_opcode(struct optcode *oc, const char *format, ...) {
   {
     char ttt[64];
 
+    va_end(ap);
+    va_start(ap, format);
     vsprintf(ttt, format, ap);
     printf("LINE %5d: OPCODE: %16s ::: %s\n", active_file_info_last->line_current, oc->op, ttt);
   }


### PR DESCRIPTION
> Don't use variadic arguments twice without resetting inbetween.

Was annoying when the DEBUG build crashed while testing in PR #164. I somehow forgot to include in PR #179. Also, I'm unsure if the `ttt` buffer has enough space, but since it is DEBUG only, I don't really care for now.