### PR TITLE
Allow smaller background

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -4196,8 +4196,8 @@ int parse_directive(void) {
     background_size = ftell(file_in_ptr);
     fseek(file_in_ptr, 0, SEEK_SET);
 
-    if (max_address < background_size) {
-      sprintf(emsg, ".BACKGROUND file \"%s\" size (%d) and ROM size (%d) don't match.\n", full_name, background_size, max_address);
+    if (background_size > max_address) {
+      sprintf(emsg, ".BACKGROUND file \"%s\" size (%d) is larger than ROM size (%d).\n", full_name, background_size, max_address);
       print_error(emsg, ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -4196,13 +4196,13 @@ int parse_directive(void) {
     background_size = ftell(file_in_ptr);
     fseek(file_in_ptr, 0, SEEK_SET);
 
-    if (max_address != background_size) {
+    if (max_address < background_size) {
       sprintf(emsg, ".BACKGROUND file \"%s\" size (%d) and ROM size (%d) don't match.\n", full_name, background_size, max_address);
       print_error(emsg, ERROR_DIR);
       return FAILED;
     }
 
-    memset(rom_banks_usage_table, 2, max_address);
+    memset(rom_banks_usage_table, 2, background_size);
     fread(rom_banks, 1, max_address, file_in_ptr);
 
     background_defined = 1;


### PR DESCRIPTION
When patching a ROM it is not unusual to also "expand" it. This change makes `.background` happy to have the input file be smaller than the output, and leaves the extra space marked as unused.