### PR TITLE
Fixing slight bug in crc32 calculation

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -153,14 +153,14 @@ unsigned long crc32(const unsigned char *s, unsigned int len)
   unsigned int i;
   unsigned long crc32val;
 
-  crc32val = 0;
+  crc32val = ~0;
   for (i = 0;  i < len;  i ++)
   {
     crc32val =
       crc32_tab[(crc32val ^ s[i]) & 0xff] ^
       (crc32val >> 8);
   }
-  return crc32val;
+  return ~crc32val;
 }
 
 /*


### PR DESCRIPTION
I was doing some work using the crc32 function in hashmap.c to generate some checksums to be read by some other processes (e.g. to get checksum of a file when wla runs, and check that file again when wla's output is loaded) and noticed there is a slight bug in the implementation, resulting in incorrect values. For example, in the following code:
```
int x = crc32("The quick brown fox jumps over the lazy dog", 43);
```
x should be `0x414fa339`, but the current implementation returns a value of `0xb9c60808`.

This change gets things back in line with compliant implementations seen in various locations, e.g. https://rosettacode.org/wiki/CRC-32#C.2B.2B