### PR TITLE
ReadTheDocs support

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,3 +116,9 @@ texinfo_documents = [
 
 if os.environ.get('READTHEDOCS') == 'True':
     html_theme = 'default'
+    # ReadTheDocs uses index.html as the index site
+    # However, the current setup doesn't do that, so instead we make
+    # a copy of wla-dx.rst to index.rst so a index.html gets created.
+    master_doc = 'index'
+    import shutil
+    shutil.copyfile('wla-dx.rst', 'index.rst')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,3 +113,6 @@ texinfo_documents = [
 #texinfo_domain_indices = True # If false, no module index is generated
 #texinfo_show_urls = 'footnote'
 #texinfo_no_detailmenu = False
+
+if os.environ.get('READTHEDOCS') == 'True':
+    html_theme = 'default'

--- a/doc/theme/layout.html
+++ b/doc/theme/layout.html
@@ -1,5 +1,8 @@
 {%- extends "haiku/layout.html" %}
 {% set script_files = [] %}
+{% if metatags is none %}
+{% set metatags = "" %}
+{% endif %}
 {% set metatags = metatags + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" %}
 {%- block csss %}
     <style>


### PR DESCRIPTION
Makes the documentation compatible with [ReadTheDocs.org](https://readthedocs.org/). It's a free service where it allows you to build (generate) the documentation and have it hosted online. I've basically done it before in PR #164, but now as a seperate PR and working. Partipally addresses #175 (no binaries generated).

[Here is an example which builds from this PR (branch).](https://wla-dx-neui.readthedocs.io/en/rtd-support/)
