### PR TITLE
QuickFix: Fix macro_runtime_current after growing macro stack

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -240,6 +240,7 @@ int macro_stack_grow(void) {
       free(macro_stack);
     }
     macro_stack = macro;
+    macro_runtime_current = &macro_stack[macro_active - 1];
   }
 
   return SUCCEEDED;


### PR DESCRIPTION
After growing the macro stack, `macro_runtime_current`, which seems
to be the last element, now then has a invalid address.

For some reason it only happened in Visual Studio 2017. Also, using
`realloc` would've been better since this is basically a big part of
`macro_grow_stack` does.

Please make sure that this is correct behaviour (aka that it should be pointing to `&macro_stack[macro_active - 1]`). I found this via my `cmake-tests` branch while on Windows with VS2017, and it seems that (at least in Debug) `free` overwrites the memory with a magic value `0xDD` and thus causes some logical error. It seems on linux this isn't being done and probably were using old values.