### PR TITLE
generate_tmp_files a bit "renovated"

### DIFF
--- a/doc/tempfiles.rst
+++ b/doc/tempfiles.rst
@@ -1,20 +1,10 @@
 Temporary Files
 ===============
 
-Note that WLA will generate two temporary files while it works. Both files
-are placed into the current working directory.
-
-======== ============== ==============
-System   File A         File B
-======== ============== ==============
-Amiga    ``wla_a.tmp``  ``wla_b.tmp``
-MSDOS    ``wla_a.tmp``  ``wla_b.tmp``
-Win32    ``.wla%PID%a`` ``.wla%PID%b``
-Unix     ``.wla%PID%a`` ``.wla%PID%b``
-AmigaOS4 ``.wla%PID%a`` ``.wla%PID%b``
-======== ============== ==============
-
-(``%PID%`` is the process id in cases where it is included)
+Note that WLA will generate an temporary files in the current working
+directory while it works. On Windows and Unix-like systems, the file is
+called ``.wla%PID%a``, where ``%PID%`` is the PID of the process.
+For other system, it's just ``wla_a.tmp``.
 
 When WLA finishes its work these two files are deleted as they serve
 of no further use.

--- a/listfile.c
+++ b/listfile.c
@@ -15,7 +15,7 @@ extern struct section_def *sections_first, *sections_last, *sec_tmp, *sec_next;
 extern struct file_name_info *file_name_info_first, *file_name_info_last, *file_name_info_tmp;
 extern unsigned char *rom_banks, *rom_banks_usage_table;
 extern FILE *file_out_ptr;
-extern char gba_tmp_name[32], *gba_tmp_last_name, tmp[4096];
+extern char *tmp_name, tmp[4096];
 extern int verbose_mode, section_status, cartridgetype, output_format;
 
 
@@ -27,8 +27,8 @@ int listfile_collect(void) {
   char c;
 
 
-  if ((file_in = fopen(gba_tmp_name, "rb")) == NULL) {
-    fprintf(stderr, "LISTFILE_COLLECT: Error opening file \"%s\".\n", gba_tmp_name);
+  if ((file_in = fopen(tmp_name, "rb")) == NULL) {
+    fprintf(stderr, "LISTFILE_COLLECT: Error opening file \"%s\".\n", tmp_name);
     return FAILED;
   }
 

--- a/main.c
+++ b/main.c
@@ -66,7 +66,7 @@ char version_string[] = "$VER: WLA-HuC6280 9.8a (20.09.2018)";
 
 char wla_version[] = "9.8a";
 
-char *tmp_name, *tmp_unfolded_name;
+char *tmp_name;
 
 extern struct incbin_file_data *incbin_file_data_first, *ifd_tmp;
 extern struct file_name_info *file_name_info_first;
@@ -185,7 +185,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  generate_tmp_names(&tmp_name, &tmp_unfolded_name);
+  generate_tmp_names(&tmp_name);
 
   file_out_ptr = fopen(tmp_name, "wb");
   if (file_out_ptr == NULL) {
@@ -520,14 +520,12 @@ void procedures_at_exit(void) {
 
   /* remove the tmp files */
   remove(tmp_name);
-  remove(tmp_unfolded_name);
 }
 
 
-int generate_tmp_names(char **first, char **second) {
+int generate_tmp_names(char **filename) {
 #if defined(UNIX) || defined(WIN32)
   static char normal[32];
-  static char unfolded[32];
   int pid;
   #if defined(UNIX)
     pid = (int)getpid();
@@ -537,12 +535,9 @@ int generate_tmp_names(char **first, char **second) {
     #error "Invalid configuration!"
   #endif
   sprintf(normal, ".wla%da", pid);
-  sprintf(unfolded, ".wla%db", pid);
-  *first = normal;
-  *second = unfolded;
+  *filename = normal;
 #else /* AMIGA, WIN32, MSDOS and others */
-  *first = "wla_a.tmp";
-  *second = "wla_b.tmp";
+  *filename = "wla_a.tmp";
 #endif
   return SUCCEEDED;
 }

--- a/main.c
+++ b/main.c
@@ -185,7 +185,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  generate_tmp_names(&tmp_name);
+  generate_tmp_name(&tmp_name);
 
   file_out_ptr = fopen(tmp_name, "wb");
   if (file_out_ptr == NULL) {
@@ -523,7 +523,7 @@ void procedures_at_exit(void) {
 }
 
 
-int generate_tmp_names(char **filename) {
+int generate_tmp_name(char **filename) {
 #if defined(UNIX) || defined(WIN32)
   static char normal[32];
   int pid;

--- a/main.c
+++ b/main.c
@@ -522,27 +522,16 @@ void procedures_at_exit(void) {
 
 
 int generate_tmp_names(void) {
-
-#ifdef UNIX
+#if defined(UNIX)
   sprintf(gba_tmp_name, ".wla%da", (int)getpid());
   sprintf(gba_unfolded_name, ".wla%db", (int)getpid());
-#endif
-
-#ifdef AMIGA
-  sprintf(gba_tmp_name, "wla_a.tmp");
-  sprintf(gba_unfolded_name, "wla_b.tmp");
-#endif
-
-#ifdef MSDOS
-#if 1 /*ndef WIN32*/
-  sprintf(gba_tmp_name, "wla_a.tmp");
-  sprintf(gba_unfolded_name, "wla_b.tmp");
-#else
+#elif defined(WIN32)
   sprintf(gba_tmp_name, ".wla%lda", GetCurrentProcessId());
   sprintf(gba_unfolded_name, ".wla%ldb", GetCurrentProcessId());
-#endif  
+#else /* AMIGA, WIN32, MSDOS and others */
+  sprintf(gba_tmp_name, "wla_a.tmp");
+  sprintf(gba_unfolded_name, "wla_b.tmp");
 #endif
-
   return SUCCEEDED;
 }
 

--- a/main.c
+++ b/main.c
@@ -525,7 +525,8 @@ void procedures_at_exit(void) {
 
 int generate_tmp_name(char **filename) {
 #if defined(UNIX) || defined(WIN32)
-  static char normal[32];
+  static char name[32]; /* Should be enough */
+  int status;
   int pid;
   #if defined(UNIX)
     pid = (int)getpid();
@@ -534,8 +535,14 @@ int generate_tmp_name(char **filename) {
   #else
     #error "Invalid configuration!"
   #endif
-  sprintf(normal, ".wla%da", pid);
-  *filename = normal;
+  status = sprintf(name, ".wla%da", pid) + 1;
+  if (status >= (int)sizeof(name)) {
+    fprintf(stderr, "MAIN: Temp filename exceeded limit: %d >= %d! "
+        "Aborting...\n",
+        status, (int)sizeof(name));
+    abort();
+  }
+  *filename = name;
 #else /* AMIGA, WIN32, MSDOS and others */
   *filename = "wla_a.tmp";
 #endif

--- a/main.h
+++ b/main.h
@@ -6,7 +6,7 @@ void procedures_at_exit(void);
 int parse_flags(char **flags, int flagc);
 int parse_and_add_definition(char *c, int contains_flag);
 int parse_and_set_incdir(char *c, int contains_flag);
-int generate_tmp_names(void);
+int generate_tmp_names(char **first, char **second);
 int generate_extra_definitions(void);
 
 /* mersenne twister */

--- a/main.h
+++ b/main.h
@@ -6,7 +6,7 @@ void procedures_at_exit(void);
 int parse_flags(char **flags, int flagc);
 int parse_and_add_definition(char *c, int contains_flag);
 int parse_and_set_incdir(char *c, int contains_flag);
-int generate_tmp_names(char **first, char **second);
+int generate_tmp_names(char **filename);
 int generate_extra_definitions(void);
 
 /* mersenne twister */

--- a/main.h
+++ b/main.h
@@ -6,7 +6,7 @@ void procedures_at_exit(void);
 int parse_flags(char **flags, int flagc);
 int parse_and_add_definition(char *c, int contains_flag);
 int parse_and_set_incdir(char *c, int contains_flag);
-int generate_tmp_names(char **filename);
+int generate_tmp_name(char **filename);
 int generate_extra_definitions(void);
 
 /* mersenne twister */

--- a/pass_3.c
+++ b/pass_3.c
@@ -15,7 +15,7 @@ extern struct section_def *sections_first, *sections_last, *sec_tmp, *sec_next;
 extern struct file_name_info *file_name_info_first, *file_name_info_last, *file_name_info_tmp;
 extern unsigned char *rom_banks, *rom_banks_usage_table;
 extern FILE *file_out_ptr;
-extern char gba_tmp_name[32], *gba_tmp_last_name, tmp[4096], emsg[1024];
+extern char *tmp_name, tmp[4096], emsg[1024];
 extern int verbose_mode, section_status, cartridgetype, output_format;
 
 
@@ -47,8 +47,8 @@ int pass_3(void) {
   if (verbose_mode == ON)
     printf("Internal pass 1...\n");
 
-  if ((f_in = fopen(gba_tmp_name, "rb")) == NULL) {
-    fprintf(stderr, "INTERNAL_PASS_1: Error opening file \"%s\".\n", gba_tmp_name);
+  if ((f_in = fopen(tmp_name, "rb")) == NULL) {
+    fprintf(stderr, "INTERNAL_PASS_1: Error opening file \"%s\".\n", tmp_name);
     return FAILED;
   }
 
@@ -670,7 +670,7 @@ int pass_3(void) {
       continue;
 
     default:
-      fprintf(stderr, "%s: INTERNAL_PASS_1: Unknown internal symbol \"%c\" in \"%s\" at offset %ld.\n", get_file_name(file_name_id), c, gba_tmp_name, ftell(f_in)-1);
+      fprintf(stderr, "%s: INTERNAL_PASS_1: Unknown internal symbol \"%c\" in \"%s\" at offset %ld.\n", get_file_name(file_name_id), c, tmp_name, ftell(f_in)-1);
       return FAILED;
     }
   }

--- a/pass_4.c
+++ b/pass_4.c
@@ -27,7 +27,7 @@ extern struct slot slots[256];
 extern struct append_section *append_sections;
 extern FILE *file_out_ptr;
 extern unsigned char *rom_banks, *rom_banks_usage_table;
-extern char gba_tmp_name[32], tmp[4096], name[32], *final_name;
+extern char *tmp_name, tmp[4096], name[32], *final_name;
 extern int rombanks, ind, inz, output_format, test_mode, listfile_data;
 
 #ifdef GB
@@ -207,8 +207,8 @@ int pass_4(void) {
   if (verbose_mode == ON)
     printf("Internal pass 2...\n");
 
-  if ((file_out_ptr = fopen(gba_tmp_name, "rb")) == NULL) {
-    fprintf(stderr, "INTERNAL_PASS_2: Error opening file \"%s\".\n", gba_tmp_name);
+  if ((file_out_ptr = fopen(tmp_name, "rb")) == NULL) {
+    fprintf(stderr, "INTERNAL_PASS_2: Error opening file \"%s\".\n", tmp_name);
     return FAILED;
   }
 


### PR DESCRIPTION
* More C like with pointers to save to (but still saves to a global variable)
* Since it seems the 2nd temp file name isn't even being used, this has been removed
* Windows now uses the `.wla%PID%a` format just as the documentation promises
* Special check if the `sprintf` call overflows the buffer, just in case

This was relatively something simple to do after the bit of CMake and the debugging of the macro stack growing thing. Maybe it's better to store the temp file to their respective location (`/tmp` on unix-like, [`GetTempPath`](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-gettemppatha) on Windows, current working directory on others).