### PR TITLE
Fix stuff PR #202 broke

### DIFF
--- a/doc/symbols.rst
+++ b/doc/symbols.rst
@@ -32,35 +32,35 @@ This is a list of all Labels to sections of the ROM, such as subroutine location
 - Format specifier: ``%2x:%4x %s``
 
 [definitions]
---------
+-------------
 This is a list of various definitions provided in code - or automatically during WLA's processing - and values associated with them. Most prominently, WLA outputs the size of each section of the ROM. Each line lists an integer value in hexadecimal, and a string (name) associated with that value.
 
 - Regex match: ``[0-9a-fA-F]{8} .*``
 - Format specifier: ``%8x %s``
 
 [breakpoints]
---------
+-------------
 This is a list of hexadecimal ROM addresses where the ``.BREAKPOINT`` directive was used in the source assembly. Each line lists an address in hexadecimal (bank and offset).
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4}``
 - Format specificer: ``%2x:%4x``
 
 [symbols]
---------
+---------
 This is a list of hexadecimal ROM addresses where the ``.SYMBOL`` directive was used in the source assembly. Each line lists an address in hexadecimal (bank and offset) and a string associated with that address. 
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4} .*``
 - Format specifier: ``%2x:%4x %s``
 
 [source files]
---------
+--------------
 These are used to identify what files were used during the assembly process, especially to map generated assembly back to source file contents. Each line lists a hexadecimal file index, a hexadecimal CRC32 checksum of the file, and a file path relative to the generated ROM's root. This could be used to load in the contents of one of the input files when running the ROM and verifying the file is up-to-date by checking its CRC32 checksum against the one generated during assembly.
 
 - Regex match: ``[0-9a-fA-F]{4} [0-9a-fA-F]{8} .*``
 - Format specifier: ``%4x %8x %s``
 
 [rom checksum]
---------
+--------------
 This is just a single line identifying what the hexadecimal CRC32 checksum of the ROM file was when the symbol file was generated. This could be used to verify that the symbol file itself is up-to-date with the ROM in question. This checksum is calculated by reading the ROM file's entire binary, and not by reading any platform-specific checksum value embedded in the ROM itself.
 
 - Regex match:  ``[0-9a-fA-F]{8}``

--- a/doc/symbols.rst
+++ b/doc/symbols.rst
@@ -12,7 +12,7 @@ Extra information for address-to-line mapping can be provided by adding the foll
 Address-to-line mappings includes information to relate lines in the source files to individual instructions in the generated ROM. This can be used to provide richer disassembly in the emulator, or allow for rich debugging in an external IDE. 
 
 Information For Emulator Developers
-===================================
+-----------------------------------
 
 In order to properly support loading of WLA symbol files, it is recommended to follow this specification below, especially so as to gracefully support future additions to the symbol files.
 
@@ -25,49 +25,56 @@ In order to properly support loading of WLA symbol files, it is recommended to f
 The following are the list of currently supported sections, what they mean, and how their data should be interpreted.
 
 [labels]
---------
+********
+
 This is a list of all Labels to sections of the ROM, such as subroutine locations, or data locations. Each line lists an address in hexadecimal (bank and offset) and a string associated with that address. This data could be used, for example, to identify what section a given target address is in, by searching for the label with the closest address less than the target address.
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4} .*``
 - Format specifier: ``%2x:%4x %s``
 
 [definitions]
--------------
+*************
+
 This is a list of various definitions provided in code - or automatically during WLA's processing - and values associated with them. Most prominently, WLA outputs the size of each section of the ROM. Each line lists an integer value in hexadecimal, and a string (name) associated with that value.
 
 - Regex match: ``[0-9a-fA-F]{8} .*``
 - Format specifier: ``%8x %s``
 
 [breakpoints]
--------------
+*************
+
 This is a list of hexadecimal ROM addresses where the ``.BREAKPOINT`` directive was used in the source assembly. Each line lists an address in hexadecimal (bank and offset).
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4}``
 - Format specificer: ``%2x:%4x``
 
 [symbols]
----------
+*********
+
 This is a list of hexadecimal ROM addresses where the ``.SYMBOL`` directive was used in the source assembly. Each line lists an address in hexadecimal (bank and offset) and a string associated with that address. 
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4} .*``
 - Format specifier: ``%2x:%4x %s``
 
 [source files]
---------------
+**************
+
 These are used to identify what files were used during the assembly process, especially to map generated assembly back to source file contents. Each line lists a hexadecimal file index, a hexadecimal CRC32 checksum of the file, and a file path relative to the generated ROM's root. This could be used to load in the contents of one of the input files when running the ROM and verifying the file is up-to-date by checking its CRC32 checksum against the one generated during assembly.
 
 - Regex match: ``[0-9a-fA-F]{4} [0-9a-fA-F]{8} .*``
 - Format specifier: ``%4x %8x %s``
 
 [rom checksum]
---------------
+**************
+
 This is just a single line identifying what the hexadecimal CRC32 checksum of the ROM file was when the symbol file was generated. This could be used to verify that the symbol file itself is up-to-date with the ROM in question. This checksum is calculated by reading the ROM file's entire binary, and not by reading any platform-specific checksum value embedded in the ROM itself.
 
 - Regex match:  ``[0-9a-fA-F]{8}``
 - Format specifier: ``%8x``
 
 [addr-to-line mapping]
---------
+**********************
+
 This is a listing of hexadecimal ROM addresses (bank and offset) each mapped to a hexadecimal file index and hexadecimal line index. The file index refers back to the file indices specified in the ``source files`` section, so that the source file name can be discovered. This information can be used to, for example, display source file information in line with disassembled code, or to communicate with an external text editor the location of the current Program Counter by specifying a source file and line instead of some address in the binary ROM file. 
 
 - Regex match: ``[0-9a-fA-F]{2}:[0-9a-fA-F]{4} [0-9a-fA-F]{4}:[0-9a-fA-F]{8}``

--- a/doc/wla-dx.rst
+++ b/doc/wla-dx.rst
@@ -21,6 +21,7 @@
     extraflags
     goodtoknow
     archoverview
+    symbols
     legal
 
 .. only:: not builder_man

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -8,7 +8,7 @@
 #include "write.h"
 #include "files.h"
 #include "analyze.h"
-#include "..\crc32.h"
+#include "../crc32.h"
 
 
 


### PR DESCRIPTION
Related to #202.

* `wlalink/write.c` tried to include `..\crc32.h`, this doesn't work on linux, since it uses `/`. (Windows should also allow `/`, I think)
* `doc/symbols.rst` subheaders doesn't had the subsections correctly aligned, so sphinx would complain and it wouldn't compile.

Not directly a thing the PR broke, but I put the information for emulator authors into a subsection rather than a section, since that info is about the symbols.

As a bonus, add the newly `doc/symbols.rst` to the main page, after the architectural overview, since I think it fits in there.