### PR TITLE
Fix CRC32s on platforms with 64-bit `long`

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -110,14 +110,14 @@ unsigned long crc32(const unsigned char *s, unsigned int len)
   unsigned int i;
   unsigned long crc32val;
 
-  crc32val = ~0;
+  crc32val = 0xffffffffUL;
   for (i = 0;  i < len;  i ++)
   {
     crc32val =
       crc32_tab[(crc32val ^ s[i]) & 0xff] ^
       (crc32val >> 8);
   }
-  return ~crc32val;
+  return ~crc32val & 0xffffffffUL;
 }
 
 

--- a/wlalink/analyze.c
+++ b/wlalink/analyze.c
@@ -11,7 +11,7 @@
 
 
 /* read an integer from t */
-#define READ_T t[3] + (t[2] << 8) + (t[1] << 16) + (t[0] << 24); t += 4;
+#define READ_T (t[3] + (t[2] << 8) + (t[1] << 16) + (t[0] << 24)); t += 4;
 
 /* read a double from t */
 #define READ_DOU {				\
@@ -363,7 +363,7 @@ int obtain_source_file_names(void) {
 
       t++;
       s->id = *(t++);
-      s->checksum = READ_T;
+      s->checksum = (unsigned) READ_T;
       s->next = NULL;
       *p = s;
       p = &(s->next);


### PR DESCRIPTION
I noticed a problem while using the list files and symbol file feature on 64-bit Linux with this kind of build:

```sh
wla-gb -i -o test.o 01-read_timing.s
wlalink -S -A linkfile test.gb
```

# Old behavior

In the resulting `test.sym` there were a couple errors. The second field of `[source files]` is supposed to be a CRC32 of the named file, but these values are actually wrong and in some cases accidentally prefixed by a 32-bit `ffffffff`:

```
[source files]
0001 fffffffff6025621 01-read_timing.s 
0002 3eaf36ca shell.inc 
0003 3dd21e10 common/build_rom.s 
0004 ffffffffc9b8b96c common/runtime.s 
0005 17d01ac0 common/gb.inc 
0006 7408d2bf common/macros.inc 
0007 ffffffffe8fb8907 common/delay.s 
0008 5edc8083 common/crc.s 
0009 ffffffffe93cd50e common/printing.s 
000a ffffffff97a165fc common/numbers.s 
000b ffffffffa877ea32 common/testing.s 
000c fffffffff86c9ebb common/console.s 
000d 06ec17a4 common/tima_64.s 

[rom checksum]
ffffffff429e747a
```

# Problem

I believe this problem wouldn't show up on 64-bit Windows where `unsigned long` happens to be 32 bits, but on 64-bit versions of Linux, macOS, and other Unix-likes, `unsigned long` is 64 bits.

First, in `crc32.c` it's necessary to mask to make sure the top 32 bits of the `unsigned long` are zeroed (if they exist).

Secondly, in `wlalink/analyze.c` the `READ_T` macro contains implicit casts to `int` because of the `<<` operator, and assigning the resulting `int` to the `unsigned long checksum` field causes a sign-extension if the top bit of the `int` (which is signed) is set and `long` is larger than `int`. This is the cause of the `ffffffff` prefix that shows up in the symbol file. Casting to `unsigned int` *first* prevents sign-extension.

I considered using `uint32_t` (from C99) but I noticed your docs say WLA DX supports C89, so I went with this lower-impact patch instead.

# New behavior

This patch corrects both problems:

```
[source files]
0001 76d3deef 01-read_timing.s 
0002 30518312 shell.inc 
0003 e03a7b12 common/build_rom.s 
0004 37617c04 common/runtime.s 
0005 84ab3619 common/gb.inc 
0006 a039b435 common/macros.inc 
0007 fdc0c35b common/delay.s 
0008 7feb04fc common/crc.s 
0009 10786944 common/printing.s 
000a 8bb25f14 common/numbers.s 
000b ba354f88 common/testing.s 
000c e9d34205 common/console.s 
000d 38fbcf56 common/tima_64.s 

[rom checksum]
084ca081
```

I confirmed correctness of the new CRC32s with this Python snippet:

```sh
$ python -c 'import sys;import zlib;print("%08x"%(zlib.crc32(sys.stdin.read())%(1<<32)))' < 01-read_timing.s
76d3deef
$ python -c 'import sys;import zlib;print("%08x"%(zlib.crc32(sys.stdin.read())%(1<<32)))' < shell.inc
30518312
$ python -c 'import sys;import zlib;print("%08x"%(zlib.crc32(sys.stdin.read())%(1<<32)))' < test.gb
084ca081
```

Thanks for your time!