### PR TITLE
Ar/buffer security fixes

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -13,7 +13,7 @@
 
 
 extern int ind, inz, i, unfolded_size, extra_definitions, d, use_incdir;
-extern char *unfolded_buffer, emsg[1024], tmp[4096], ext_incdir[MAX_NAME_LENGTH + 2];
+extern char *unfolded_buffer, tmp[4096], emsg[sizeof(tmp) + MAX_NAME_LENGTH + 1 + 1024], ext_incdir[MAX_NAME_LENGTH + 2];
 extern FILE *file_out_ptr;
 
 struct incbin_file_data *incbin_file_data_first = NULL, *ifd_tmp;

--- a/include_file.c
+++ b/include_file.c
@@ -13,7 +13,7 @@
 
 
 extern int ind, inz, i, unfolded_size, extra_definitions, d, use_incdir;
-extern char *unfolded_buffer, emsg[1024], tmp[4096], ext_incdir[MAX_NAME_LENGTH + 1];
+extern char *unfolded_buffer, emsg[1024], tmp[4096], ext_incdir[MAX_NAME_LENGTH + 2];
 extern FILE *file_out_ptr;
 
 struct incbin_file_data *incbin_file_data_first = NULL, *ifd_tmp;

--- a/main.c
+++ b/main.c
@@ -94,7 +94,7 @@ int output_format = OUTPUT_NONE, verbose_mode = OFF, test_mode = OFF;
 int extra_definitions = OFF, commandline_parsing = ON, makefile_rules = NO;
 int listfile_data = NO, quiet = NO, use_incdir = NO;
 
-char *final_name = NULL, *asm_name = NULL, ext_incdir[MAX_NAME_LENGTH + 1];
+char *final_name = NULL, *asm_name = NULL, ext_incdir[MAX_NAME_LENGTH + 2];
 
 
 int main(int argc, char *argv[]) {

--- a/parse.c
+++ b/parse.c
@@ -934,9 +934,10 @@ int _expand_macro_arguments_one_pass(char *in, int *expands, int *move_up) {
     
     return FAILED;
   }
-  
-  strncpy(in, expanded_macro_string, MAX_NAME_LENGTH);
-	
+
+  memcpy(in, expanded_macro_string, MAX_NAME_LENGTH);
+  in[MAX_NAME_LENGTH] = '\0';
+
   return SUCCEEDED;
 }
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -86,7 +86,7 @@ int name_defined = 0;
 extern int operand_hint;
 #endif
 
-char tmp[4096], emsg[1024];
+char tmp[4096], emsg[sizeof(tmp) + MAX_NAME_LENGTH + 1 + 1024];
 char *tmp_bf;
 char cp[256];
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -6292,7 +6292,7 @@ int parse_directive(void) {
 
   if (strcaselesscmp(cp, "SNESNATIVEVECTOR") == 0) {
 
-    int cop_defined = 0, brk_defined = 0, abort_defined = 0, base_address;
+    int cop_defined = 0, brk_defined = 0, abort_defined = 0, base_address = 0;
     int nmi_defined = 0, unused_defined = 0, irq_defined = 0;
     char cop[512], brk[512], abort[512], nmi[512], unused[512], irq[512];
 
@@ -6514,7 +6514,7 @@ int parse_directive(void) {
 
   if (strcaselesscmp(cp, "SNESEMUVECTOR") == 0) {
 
-    int cop_defined = 0, unused_defined = 0, abort_defined = 0, base_address;
+    int cop_defined = 0, unused_defined = 0, abort_defined = 0, base_address = 0;
     int nmi_defined = 0, reset_defined = 0, irqbrk_defined = 0;
     char cop[512], unused[512], abort[512], nmi[512], reset[512], irqbrk[512];
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -2590,8 +2590,13 @@ int parse_directive(void) {
                        return FAILED;
                      }
                      sj->next = NULL;
-                     sprintf(sj->name, "%s.%s", si->name, sti->name);
                      sj->size = 0;
+                     if (strlen(si->name) + strlen(sti->name) + 1 < sizeof(sj->name))
+                       sprintf(sj->name, "%s.%s", si->name, sti->name);
+                     else {
+                       print_error("Maximum length exceeded for unique name of nested STRUCT.\n", ERROR_DIR);
+                       return FAILED;
+	             }
                      
                      if (sl != NULL)
                        sl->next = sj;
@@ -2605,11 +2610,16 @@ int parse_directive(void) {
                     return FAILED;
                   }
                   sj->next = NULL;
-                  if (arr == 1)
-                     sprintf(sj->name, "%s.%s", si->name, sti->name);
-                  else
-                     sprintf(sj->name, "%s.%i.%s", si->name, j + 1, sti->name);
                   sj->size = sti->size;
+                  if ((arr == 1) &&
+                      (strlen(si->name) + strlen(sti->name) + 1 < sizeof(sj->name)))
+                    sprintf(sj->name, "%s.%s", si->name, sti->name);
+                  else if (strlen(si->name) + strlen(sti->name) + 1 + INT_MAX_DECIMAL_DIGITS < sizeof(sj->name))
+                    sprintf(sj->name, "%s.%i.%s", si->name, j + 1, sti->name);
+                  else {
+                    print_error("Maximum length exceeded for unique name of item in nested STRUCT.\n", ERROR_DIR);
+                    return FAILED;
+	          }
                   
                   if (sl != NULL)
                     sl->next = sj;

--- a/shared.h
+++ b/shared.h
@@ -4,6 +4,7 @@
 
 /* want to use longer strings and labels? change this - PS. it doesn't contain the null terminator */
 #define MAX_NAME_LENGTH 255
+#define INT_MAX_DECIMAL_DIGITS 10
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/wlalink/files.c
+++ b/wlalink/files.c
@@ -23,7 +23,7 @@ extern char ext_libdir[MAX_NAME_LENGTH + 1];
 int load_files(char *argv[], int argc) {
 
   int state = STATE_NONE, i, x, line, bank, slot, base, bank_defined, slot_defined, base_defined, n;
-  char tmp[1024], token[1024], tmp_token[MAX_NAME_LENGTH + 1];
+  char tmp[1024], token[1024], tmp_token[1024 + MAX_NAME_LENGTH + 2];
   struct label *l;
   FILE *fop, *f;
 

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -2127,14 +2127,15 @@ int generate_sizeof_label_definitions(void) {
       return FAILED;
     }
 
-    if (strlen(labels[j]->name)+8 > MAX_NAME_LENGTH) {
+    if (strlen(labels[j]->name)+8 >= sizeof(l->name)) {
       fprintf(stderr, "GENERATE_SIZEOF_LABEL_DEFINITIONS: Expanded label name \"_sizeof_%s\" is %d characters too large.\n",
-              labels[j]->name, (int)(strlen(labels[j]->name)-MAX_NAME_LENGTH+8));
+              labels[j]->name, (int)(strlen(labels[j]->name)+8+1-sizeof(l->name)));
       free(labels);
       return FAILED;
     }
+    else
+      sprintf(l->name, "_sizeof_%s", labels[j]->name);
 
-    sprintf(l->name, "_sizeof_%s", labels[j]->name);
     l->status = LABEL_STATUS_DEFINE;
     l->address = size;
     l->base = 0;


### PR DESCRIPTION
These changes fix several compilation warnings (gcc 8.2) and work around several buffer overflow / not-null-terminated issues. Do note the first commit touches CMakeLists.txt, so check if that change is something you agree with.

While these should cover most of the string buffer overflow cases, it does not cover any of the truncation cases. In particular, these would be in pass_1.c on lines 2609, 2593, and 2611. Basically, two structure items (or similar) are being concatenated as "%s.%s" or "%s.%i.%s" or whatever. The two strings are both up to MAX_NAME_LENGTH long, but the destination buffer is also MAX_NAME_LENGTH in size, so the final stored result could very well be indistinguishable due to truncation. gcc itself had hinted this could be the case, but I'm not sure how it should be handled, so I left those alone.

Edit: Just wanted to make it clear I did not & cannot easily test with MSVC to verify compatibility of the _snprintf commit. :)