### PR TITLE
Improve support/docs for some (rare) GB header values

### DIFF
--- a/doc/gb-support.rst
+++ b/doc/gb-support.rst
@@ -68,8 +68,10 @@ one the the following values to ``.CARTRIDGETYPE`` in the GB-Z80 version of WLA.
 ``$1C`` ROM              MBC5                            RUMBLE
 ``$1D`` ROM              MBC5   SRAM                     RUMBLE
 ``$1E`` ROM              MBC5   SRAM   BATTERY           RUMBLE
-``$1F`` Pocket Camera
+``$20`` MBC6
+``$22`` MBC7
 ``$BE`` Pocket Voice
+``$FC`` Pocket Camera
 ``$FD`` Bandai TAMA5
 ``$FE`` Hudson HuC-3
 ``$FF`` Hudson HuC-1

--- a/doc/gb-support.rst
+++ b/doc/gb-support.rst
@@ -35,6 +35,7 @@ of WLA.
 ``$02``  64kbit     8kByte    1 bank
 ``$03`` 256kbit    32kByte    4 banks
 ``$04``   1Mbit   128kByte   16 banks
+``$05`` 512kbit    64kByte    8 banks
 ======= ======== ========== ==========
 
 Cartridge Type

--- a/doc/gb-support.rst
+++ b/doc/gb-support.rst
@@ -16,6 +16,8 @@ one of the following values to ``.ROMBANKS``.
 ``$04``   4Mbit   512KByte    32 banks
 ``$05``   8Mbit     1MByte    64 banks
 ``$06``  16Mbit     2MByte   128 banks
+``$07``  32Mbit     4MByte   256 banks
+``$08``  64Mbit     8MByte   512 banks
 ``$52``   9Mbit   1.1MByte    72 banks
 ``$53``  10Mbit   1.2MByte    80 banks
 ``$54``  12Mbit   1.5MByte    96 banks

--- a/pass_1.c
+++ b/pass_1.c
@@ -7493,7 +7493,7 @@ int parse_directive(void) {
       }
     }
 
-    if (d != 0 && d != 1 && d != 2 && d != 3 && d != 4) {
+    if (d != 0 && d != 1 && d != 2 && d != 3 && d != 4 && d != 5) {
       print_error("Unsupported RAM size.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -4330,7 +4330,7 @@ int directive_rombanks(void) {
 
 #ifdef GB
   if (d != 2 && d != 4 && d != 8 && d != 16 && d != 32 && d != 64 &&
-      d != 128 && d != 256 && d != 72 && d != 80 && d != 96) {
+      d != 128 && d != 256 && d != 512 && d != 72 && d != 80 && d != 96) {
     print_error("Unsupported amount of ROM banks.\n", ERROR_DIR);
     return FAILED;
   }
@@ -4351,6 +4351,8 @@ int directive_rombanks(void) {
     romtype = 6;
   else if (d == 256)
     romtype = 7;
+  else if (d == 512)
+    romtype = 8;
   else if (d == 72)
     romtype = 0x52;
   else if (d == 80)
@@ -4631,7 +4633,7 @@ int directive_rombankmap(void) {
 
 #ifdef GB
   if (b != 2 && b != 4 && b != 8 && b != 16 && b != 32 && b != 64 &&
-      b != 128 && b != 256 && b != 72 && b != 80 && b != 96) {
+      b != 128 && b != 256 && b != 512 && b != 72 && b != 80 && b != 96) {
     print_error("Unsupported amount of ROM banks.\n", ERROR_DIR);
     return FAILED;
   }
@@ -4652,6 +4654,8 @@ int directive_rombankmap(void) {
     romtype = 6;
   else if (b == 256)
     romtype = 7;
+  else if (b == 512)
+    romtype = 8;
   else if (b == 72)
     romtype = 0x52;
   else if (b == 80)


### PR DESCRIPTION
* 64 Mbit ROM: supported by MBC5. In official games used by Densha De Go 2
* 512 kbit RAM: supported by MBC30 (variant of MBC3). In official games used by Japanese Pokemon Crystal
* (docs only) MBC6: In official games used by Net De Get 100
* (docs only) MBC7: In official games used by Command Master, and the two versions of Kirby Tilt 'n' Tumble
* Pocket Camera should have value $FC