### PR TITLE
Git: Make makefiles ending in .gb be text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,6 +44,7 @@ historical/wlad_new/makefile.win32* text eol=crlf
 *.exe   binary
 *.bin   binary
 *.gb    binary
+historical/makefiles/*make*.gb -binary
 *.smc   binary
 *.sfc   binary
 *.o     binary


### PR DESCRIPTION
Because of the later `.gb binary`, git thought `smake.gb` and similar were binary files instead of text files. This fixes it for makefiles.

I've noticed this when rebasing #184 and it wouldn't merge the "binary files". 