### PR TITLE
Make test failures obvious

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -9,6 +9,8 @@
 # these tests aren't really unit tests, but hopefully one day they will be. :)
 #
 
+set -e
+
 changePlatform() {
     echo ""
     echo "************************************************************"


### PR DESCRIPTION
When running wla-dx' tests, I was surprised that the run_unit_tests.sh script succeeded despite some errors being reported. run_unit_tests.sh basically never exits with a failure. This makes it difficult to see if a test actually failed; you need to sift through hundreds of lines of output for any interesting error messages.

Make run_unit_tests.sh fail as soon as a failure is encountered. This puts the error message at the bottom, and makes run_unit_tests.sh return a non-zero exit code if any test fails.

---

When running run_unit_tests.sh, you will only notice if wla produces incorrect binaries if you look carefully at the script's (very verbose) output. Make finding test failures easier by making byte_tester propagate a failure exit code up to run_unit_tests.sh.