### PR TITLE
Fix checksum for 24 Mbit SNES ROMs

### DIFF
--- a/examples/65816/checksum_12mbit_lorom/linkfile
+++ b/examples/65816/checksum_12mbit_lorom/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/examples/65816/checksum_12mbit_lorom/main.s
+++ b/examples/65816/checksum_12mbit_lorom/main.s
@@ -1,0 +1,35 @@
+.lorom
+.memorymap
+	slotsize $8000
+	defaultslot 0
+	slot 0 $8000
+.endme
+
+.rombanksize $8000
+.rombanks $30
+
+; For a $30-bank (12 Mbit) ROM, SNES sums the first $20 banks (8 Mbit) once,
+; and the following $10 banks (4 Mbit) twice.
+.define LOW_BANK_BYTE $10
+.define HIGH_BANK_BYTE $01
+.bank $1f
+.db LOW_BANK_BYTE
+.bank $2e
+.db HIGH_BANK_BYTE
+
+.define ROM_TYPE_SUM $20 ; .lorom
+.define TEST_MARKER_SUM $3c + $3e + $43*2 + $4b*2 ; "CK>", "<CK"
+.define CHECKSUM_SUM $ff*2
+.define SUM ROM_TYPE_SUM + TEST_MARKER_SUM + CHECKSUM_SUM + LOW_BANK_BYTE + HIGH_BANK_BYTE*2
+.print "Expected checksum: ", hex (SUM & $ffff), "\n"
+.print "Expected complement checksum: ", hex ((SUM ~ $ffff) & $ffff), "\n"
+
+.bank 0
+.define SNES_CHECKSUM $7fdc
+.define SNES_CHECKSUM_SIZE 4
+.org SNES_CHECKSUM - 3
+.db "CK>"
+.org SNES_CHECKSUM + SNES_CHECKSUM_SIZE
+.db "<CK"
+
+.computesneschecksum

--- a/examples/65816/checksum_12mbit_lorom/makefile
+++ b/examples/65816/checksum_12mbit_lorom/makefile
@@ -1,0 +1,22 @@
+
+CC = wla-65816
+CFLAGS = -o
+LD = wlalink
+LDFLAGS =
+
+SFILES = main.s
+IFILES = 
+OFILES = main.o
+
+all: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom

--- a/examples/65816/checksum_12mbit_lorom/testsfile
+++ b/examples/65816/checksum_12mbit_lorom/testsfile
@@ -1,0 +1,2 @@
+result.rom
+TEST-CK CK START 39 FC C6 03 END

--- a/examples/65816/checksum_24mbit_lorom/linkfile
+++ b/examples/65816/checksum_24mbit_lorom/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/examples/65816/checksum_24mbit_lorom/main.s
+++ b/examples/65816/checksum_24mbit_lorom/main.s
@@ -1,0 +1,35 @@
+.lorom
+.memorymap
+	slotsize $8000
+	defaultslot 0
+	slot 0 $8000
+.endme
+
+.rombanksize $8000
+.rombanks $60
+
+; For a $60-bank (24 Mbit) ROM, SNES sums the first $40 banks (16 Mbit) once,
+; and the following $20 banks (8 Mbit) twice.
+.define LOW_BANK_BYTE $10
+.define HIGH_BANK_BYTE $01
+.bank $10
+.db LOW_BANK_BYTE
+.bank $5f
+.db HIGH_BANK_BYTE
+
+.define ROM_TYPE_SUM $20 ; .lorom
+.define TEST_MARKER_SUM $3c + $3e + $43*2 + $4b*2 ; "CK>", "<CK"
+.define CHECKSUM_SUM $ff*2
+.define SUM ROM_TYPE_SUM + TEST_MARKER_SUM + CHECKSUM_SUM + LOW_BANK_BYTE + HIGH_BANK_BYTE*2
+.print "Expected checksum: ", hex (SUM & $ffff), "\n"
+.print "Expected complement checksum: ", hex ((SUM ~ $ffff) & $ffff), "\n"
+
+.bank 0
+.define SNES_CHECKSUM $7fdc
+.define SNES_CHECKSUM_SIZE 4
+.org SNES_CHECKSUM - 3
+.db "CK>"
+.org SNES_CHECKSUM + SNES_CHECKSUM_SIZE
+.db "<CK"
+
+.computesneschecksum

--- a/examples/65816/checksum_24mbit_lorom/makefile
+++ b/examples/65816/checksum_24mbit_lorom/makefile
@@ -1,0 +1,22 @@
+
+CC = wla-65816
+CFLAGS = -o
+LD = wlalink
+LDFLAGS =
+
+SFILES = main.s
+IFILES = 
+OFILES = main.o
+
+all: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom

--- a/examples/65816/checksum_24mbit_lorom/testsfile
+++ b/examples/65816/checksum_24mbit_lorom/testsfile
@@ -1,0 +1,2 @@
+result.rom
+TEST-CK CK START 39 FC C6 03 END

--- a/examples/65816/checksum_8mbit_hirom/linkfile
+++ b/examples/65816/checksum_8mbit_hirom/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/examples/65816/checksum_8mbit_hirom/main.s
+++ b/examples/65816/checksum_8mbit_hirom/main.s
@@ -1,0 +1,33 @@
+.hirom
+.memorymap
+	slotsize $10000
+	defaultslot 0
+	slot 0 $0000
+.endme
+
+.rombanksize $10000
+.rombanks $10
+
+; For a $10-bank (8 Mbit) ROM, SNES sums the first $10 banks (8 Mbit) once.
+.define LOW_BANK_BYTE $07
+.bank $01
+.db LOW_BANK_BYTE
+.bank $0f
+.db LOW_BANK_BYTE
+
+.define ROM_TYPE_SUM $21 ; .hirom
+.define TEST_MARKER_SUM $3c + $3e + $43*2 + $4b*2 ; "CK>", "<CK"
+.define CHECKSUM_SUM $ff*2
+.define SUM ROM_TYPE_SUM + TEST_MARKER_SUM + CHECKSUM_SUM + LOW_BANK_BYTE*2
+.print "Expected checksum: ", hex (SUM & $ffff), "\n"
+.print "Expected complement checksum: ", hex ((SUM ~ $ffff) & $ffff), "\n"
+
+.bank 0
+.define SNES_CHECKSUM $ffdc
+.define SNES_CHECKSUM_SIZE 4
+.org SNES_CHECKSUM - 3
+.db "CK>"
+.org SNES_CHECKSUM + SNES_CHECKSUM_SIZE
+.db "<CK"
+
+.computesneschecksum

--- a/examples/65816/checksum_8mbit_hirom/makefile
+++ b/examples/65816/checksum_8mbit_hirom/makefile
@@ -1,0 +1,22 @@
+
+CC = wla-65816
+CFLAGS = -o
+LD = wlalink
+LDFLAGS =
+
+SFILES = main.s
+IFILES = 
+OFILES = main.o
+
+all: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom

--- a/examples/65816/checksum_8mbit_hirom/testsfile
+++ b/examples/65816/checksum_8mbit_hirom/testsfile
@@ -1,0 +1,2 @@
+result.rom
+TEST-CK CK START 3C FC C3 03 END

--- a/examples/65816/checksum_8mbit_lorom/linkfile
+++ b/examples/65816/checksum_8mbit_lorom/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/examples/65816/checksum_8mbit_lorom/main.s
+++ b/examples/65816/checksum_8mbit_lorom/main.s
@@ -1,0 +1,35 @@
+.lorom
+.memorymap
+	slotsize $8000
+	defaultslot 0
+	slot 0 $8000
+.endme
+
+.rombanksize $8000
+.rombanks $20
+
+; For a $20-bank (8 Mbit) ROM, SNES sums the first $20 banks (8 Mbit) once.
+.define LOW_BANK_BYTE $07
+.bank $0f
+.db LOW_BANK_BYTE
+.bank $10
+.db LOW_BANK_BYTE
+.bank $1f
+.db LOW_BANK_BYTE
+
+.define ROM_TYPE_SUM $20 ; .lorom
+.define TEST_MARKER_SUM $3c + $3e + $43*2 + $4b*2 ; "CK>", "<CK"
+.define CHECKSUM_SUM $ff*2
+.define SUM ROM_TYPE_SUM + TEST_MARKER_SUM + CHECKSUM_SUM + LOW_BANK_BYTE*3
+.print "Expected checksum: ", hex (SUM & $ffff), "\n"
+.print "Expected complement checksum: ", hex ((SUM ~ $ffff) & $ffff), "\n"
+
+.bank 0
+.define SNES_CHECKSUM $7fdc
+.define SNES_CHECKSUM_SIZE 4
+.org SNES_CHECKSUM - 3
+.db "CK>"
+.org SNES_CHECKSUM + SNES_CHECKSUM_SIZE
+.db "<CK"
+
+.computesneschecksum

--- a/examples/65816/checksum_8mbit_lorom/makefile
+++ b/examples/65816/checksum_8mbit_lorom/makefile
@@ -1,0 +1,22 @@
+
+CC = wla-65816
+CFLAGS = -o
+LD = wlalink
+LDFLAGS =
+
+SFILES = main.s
+IFILES = 
+OFILES = main.o
+
+all: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom

--- a/examples/65816/checksum_8mbit_lorom/testsfile
+++ b/examples/65816/checksum_8mbit_lorom/testsfile
@@ -1,0 +1,2 @@
+result.rom
+TEST-CK CK START 36 FC C9 03 END

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -82,6 +82,10 @@ runTest base_test_1
 runTest base_test_2
 runTest base_test_3
 runTest base_test_4
+runTest checksum_12mbit_lorom
+runTest checksum_24mbit_lorom
+runTest checksum_8mbit_hirom
+runTest checksum_8mbit_lorom
 runTest linker_test
 runTest name_test
 runTest operand_hint_test


### PR DESCRIPTION
For 24 Mbit SNES/65816 ROMs like EarthBound and Super Metroid, the .computesneschecksum directive produces the wrong checksum. The SNES checksum algorithm implements mirroring incorrectly; mirroring should round to the next power of two, but .computesneschecksum instead rounds to the nearest 4 Mbit boundary.

Fix the implementation of .computesneschecksum for LOROM, HIROM, and EXLOROM variants.

I manually verified that this change produces correct checksums for a variety of licensed SNES ROMs, including LOROM, HIROM, and SA-1 ROM variants. I did not test any EXLOROM or EXHIROM ROMs.