### PR TITLE
Allow commiting Makefiles in the examples/*/*/ dir

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+# system/test/Makefile
+!*/*/[mM]akefile


### PR DESCRIPTION
After complaining at https://github.com/vhelin/wla-dx/pull/256#issuecomment-529199305, I made this PR because it's currently reasonable that Makefiles are commited for the examples directory.

Note that it only matches 2 directories deep in the examples directory, so for example those will be "tracked":

```
examples/gb-z80/union_test/makefile
examples/65816/name_test/makefile
examples/6510/operand_hint_test/makefile
examples/huc6280/ram_sections/makefile
```

But not these ones:

```
examples/makefile
examples/gb-z80/makefile
examples/gb-z80/lib/src/makefile
```

The reason to do this is because this is currently the only pattern where makefiles are placed.