### PR TITLE
Fix corrupt NO$SNS symbol file for 24-bit symbols

### DIFF
--- a/examples/65816/nocashsns_symbol_file/check_symbols.sh
+++ b/examples/65816/nocashsns_symbol_file/check_symbols.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+set -u
+
+symbol_file="${1}"
+
+expect_line() {
+  if ! grep -q "^${1}$" <"${symbol_file}"; then
+    printf 'error: expected line not present in %s: %s\n' "${symbol_file}" "${1}" >&2
+    dump_symbol_file
+    exit 1
+  fi
+}
+
+dump_symbol_file() {
+    printf 'note: content of %s:\n' "${symbol_file}"
+    while read line; do
+      printf '  %s\n' "${line}"
+    done <"${symbol_file}"
+}
+
+# All labels are in the symbol file.
+expect_line '00008000 _private_label_8000'
+expect_line '00008000 public_label_8001'
+expect_line '00108000 label_108001'
+
+# Only public defines are in the symbol file.
+expect_line '00005678 public_define_5678'
+
+# 24-bit defines are in the symbol file.
+expect_line '00abcdef long_define_abcdef'

--- a/examples/65816/nocashsns_symbol_file/main.s
+++ b/examples/65816/nocashsns_symbol_file/main.s
@@ -1,0 +1,25 @@
+.lorom
+.memorymap
+	slotsize $8000
+	defaultslot 0
+	slot 0 $8000
+.endme
+
+.rombanksize $8000
+.rombanks $20
+
+.bank $0 slot $0
+.org $0000
+_private_label_8000:
+public_label_8001:
+
+.bank $10 slot $0
+.org $0000
+label_108001:
+
+.define private_define_1234 $1234
+.define public_define_5678 $5678
+.export public_define_5678
+
+.define long_define_abcdef $abcdef
+.export long_define_abcdef

--- a/examples/65816/nocashsns_symbol_file/makefile
+++ b/examples/65816/nocashsns_symbol_file/makefile
@@ -1,0 +1,27 @@
+
+CC = wla-65816
+CFLAGS = -o
+LD = wlalink
+LDFLAGS = -s
+
+SFILES = main.s
+IFILES =
+OFILES = main.o
+
+all: result.rom check
+
+result.rom: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+check: result.rom
+	./check_symbols.sh result.sym
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom result.sym

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -88,6 +88,7 @@ runTest checksum_8mbit_hirom
 runTest checksum_8mbit_lorom
 runTest linker_test
 runTest name_test
+runTest nocashsns_symbol_file
 runTest operand_hint_test
 cd ..
 

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -1088,7 +1088,7 @@ int write_symbol_file(char *outname, unsigned char mode, unsigned char outputAdd
 	if (l->status == LABEL_STATUS_LABEL)
 	  fprintf(f, "%.4x%.4x %s\n", get_snes_pc_bank(l) >> 16, (int)l->address, l->name);
 	else
-	  fprintf(f, "0000%.4x %s\n", (int)l->address, l->name);
+	  fprintf(f, "%.8x %s\n", (int)l->address, l->name);
       }
       l = l->next;
     }


### PR DESCRIPTION
When a non-label symbol has a 24-bit value, NO$SNS fails to load the .sym file generated by wla-dx, reporting the following error:

> Symbolic Info File Corrupt,
> Line   247

This happens because the .sym file contains bad data:

    000088b8 _sizeof_a
    000056fc _sizeof_b
    00004310d _sizeof_c
    000016eba _sizeof_d
    00004000 _sizeof_e
    00001600 _sizeof_f

Fix wla-dx' formatting of the .sym file so NO$SNS can load them.