### PR TITLE
Add support for the W65C02S's WAI and STP instructions

### DIFF
--- a/opcodes_65c02.c
+++ b/opcodes_65c02.c
@@ -355,6 +355,8 @@ struct optcode opt_table[] = {
   { "STA.B x", 0x85, 4, 0 },
   { "STA.W ?", 0x8D, 2, 0 },
 
+  { "STP", 0xDB, 0, 0 },
+
   { "STX x,Y", 0x96, 4, 0 },
   { "STX x", 0x86, 4, 1 },
   { "STX ?", 0x8E, 2, 0 },
@@ -394,6 +396,8 @@ struct optcode opt_table[] = {
   { "TSB ?", 0x0C, 2, 0 },
   { "TSB.B x", 0x04, 4, 1 },
   { "TSB.W ?", 0x0C, 2, 0 },
+
+  { "WAI", 0xCB, 0, 0 },
 
   { "E", 0x100, 0xFF, 0 }
 };


### PR DESCRIPTION
WLA currently has support for all W65C02S instructions—including the "Rockwell bit extensions"—except for `WAI` and `STP`. My applications for the W65C02S use `WAI` extensively, and my [exhaustive testing of the W65C02S](https://github.com/SolraBizna/65test) characterized both instructions. I've been making use of them by adding the following to my common header:

```
.MACRO WAI
.DB $CB
.ENDM
.MACRO STP
.DB $DB
.ENDM
```

...but that feels silly. So I added them to WLA.

I believe that these instructions are new to the S (static logic) version of this processor, but I have no proof. Nevertheless, here they are. They're not supported by all 65C02s, but the Rockwell bit extensions are also only supported on Rockwell and WDC 65C02s, so I assume that's not a problem.

(While I was in here, I saw that the `SMB` instructions aren't quite in alphabetical order in the table. Is that a problem?)