### PR TITLE
Make buffer large enough for sprintf's output

### DIFF
--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -60,7 +60,7 @@ int num_sorted_anonymous_labels = 0;
 extern struct section_fix *sec_fix_first, *sec_fix_tmp;
 extern char mem_insert_action[MAX_NAME_LENGTH*3 + 1024];
 extern int emptyfill;
-char ext_libdir[MAX_NAME_LENGTH + 1];
+char ext_libdir[MAX_NAME_LENGTH + 2];
 
 
 #ifdef WLALINK_DEBUG


### PR DESCRIPTION
Compiling current master with GCC gives the following warning:

```
.../wlalink/main.c: In function ‘parse_and_set_libdir’:
.../wlalink/main.c:897:27: warning: ‘sprintf’ may write a terminating nul past the end of
the destination [-Wformat-overflow=]
   sprintf(ext_libdir, "%s/", n);
                           ^
.../wlalink/main.c:897:3: note: ‘sprintf’ output between 2 and 257 bytes into a
destination of size 256
   sprintf(ext_libdir, "%s/", n);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is trivial to fix by increasing the size of `ext_libdir` by one byte. (Really, `snprintf` should be used, but I assume there's some historical reason it isn't being used.)