### PR TITLE
Better handling of unary operators

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -646,7 +646,8 @@ int stack_calculate(char *in, int *value) {
 
   /* fix the sign in every operand */
   for (b = 1, k = 0; k < q; k++) {
-    if ((q - k) != 1 && si[k].type == STACK_ITEM_TYPE_OPERATOR && si[k + 1].type == STACK_ITEM_TYPE_OPERATOR && si[k + 1].value != SI_OP_BANK) {
+    if ((q - k) != 1 && si[k].type == STACK_ITEM_TYPE_OPERATOR && si[k + 1].type == STACK_ITEM_TYPE_OPERATOR && si[k + 1].value != SI_OP_BANK
+        && si[k + 1].value != SI_OP_HIGH_BYTE && si[k + 1].value != SI_OP_LOW_BYTE) {
       if (si[k].value != SI_OP_LEFT && si[k].value != SI_OP_RIGHT && si[k + 1].value != SI_OP_LEFT && si[k + 1].value != SI_OP_RIGHT) {
 	print_error("Error in computation syntax.\n", ERROR_STC);
 	return FAILED;

--- a/stack.c
+++ b/stack.c
@@ -758,39 +758,15 @@ int stack_calculate(char *in, int *value) {
 	  b++;
 	}
 	else if (si[k].value == SI_OP_LOW_BYTE) {
-	  b--;
-	  while (b != -1 && op[b] != SI_OP_LEFT) {
-	    ta[d].type = STACK_ITEM_TYPE_OPERATOR;
-	    ta[d].value = op[b];
-	    b--;
-	    d++;
-	  }
-	  b++;
-	  op[b] = SI_OP_LOW_BYTE;
+	  op[b] = SI_OP_LOW_BYTE; /* Unary operator */
 	  b++;
 	}
 	else if (si[k].value == SI_OP_HIGH_BYTE) {
-	  b--;
-	  while (b != -1 && op[b] != SI_OP_LEFT) {
-	    ta[d].type = STACK_ITEM_TYPE_OPERATOR;
-	    ta[d].value = op[b];
-	    b--;
-	    d++;
-	  }
-	  b++;
-	  op[b] = SI_OP_HIGH_BYTE;
+	  op[b] = SI_OP_HIGH_BYTE; /* Unary operator */
 	  b++;
 	}
 	else if (si[k].value == SI_OP_BANK) {
-	  b--;
-	  while (b != -1 && op[b] != SI_OP_LEFT) {
-	    ta[d].type = STACK_ITEM_TYPE_OPERATOR;
-	    ta[d].value = op[b];
-	    b--;
-	    d++;
-	  }
-	  b++;
-	  op[b] = SI_OP_BANK;
+	  op[b] = SI_OP_BANK; /* Unary operator */
 	  b++;
 	}
 	else if (si[k].value == SI_OP_XOR) {


### PR DESCRIPTION
Possible fix for #293. The jist of this is that you should be able to do ".db $01 | :label" without having to wrap ":label" in brackets. Same with ">" and "<" operators.

I don't _entirely_ know what I did, so I guess take this with a massive grain of salt? I just sort of copied the way multiplication appears to handle precedence. But all of the tests pass, and my massive project compiles, so it doesn't seem too broken?

Review thoroughly.