### PR TITLE
Fix zero size sections crashing wlalink

### DIFF
--- a/wlalink/analyze.c
+++ b/wlalink/analyze.c
@@ -116,6 +116,9 @@ int add_section(struct section *s) {
     memcpy(data, s->data, s->size);
     s->data = data;
   }
+  else {
+    s->data = NULL;
+  }
 
   s->file_id = obj_tmp->id;
   s->next = NULL;


### PR DESCRIPTION
Fix wlalink crash on zero-size library sections.

Calling YAGNI might be appropriate but I think that hardening the linker is a good option.

I'm developing an LLVM backend for the 65816, with the primary use case being the Super Nintendo. The backend does not have its own linker, but uses the library format of WLA-DX to be able to comfortably link info game ROM files. It can output some zero-size sections at the moment.

https://github.com/Peppar/llvm-project-C65/tree/task-bringuptodate
