### PR TITLE
Accept "appendto" in linkfiles

### DIFF
--- a/doc/linking.rst
+++ b/doc/linking.rst
@@ -62,14 +62,16 @@ to link together. Here's the format:
 
 5. If you have RAMSECTIONs inside the libraries, you must place
    the sections inside BANKs and SLOTs (ORG and ORGA are optional).
-   Note that you can also change the type and priority of the section::
+   Note that you can also change the type and priority of the section,
+   and can use appendto::
 
         [ramsections]
         bank 0 slot 3 org $0 "library 1 vars 1"
 	bank 0 slot 3 orga $6100 priority 100 force "library 1 vars 2"
+	bank 0 slot 3 appendto "library 1 vars 2" "library 1 vars 3"
 
-6. If you want to relocate normal sections, do as follows (ORG and ORGA
-   are optional, but useful)::
+6. If you want to relocate normal sections, do as follows (ORG, ORGA,
+   and APPENDTO are optional, but useful)::
 
         [sections]
 	bank 0 slot 1 org $100 "MusicPlayer"

--- a/examples/8080/linker_test/linkfile
+++ b/examples/8080/linker_test/linkfile
@@ -10,3 +10,4 @@ bank 0 slot $D000 force priority 100 VARS
 [sections]
 bank 0 slot $8000 orga $8200 priority 1 "DUMMY"
 bank 0 slot $8000 orga $8200 priority 0 "DUMMY2"
+bank 0 slot $8000 appendto "DUMMY" "DUMMY3"

--- a/examples/8080/linker_test/main.s
+++ b/examples/8080/linker_test/main.s
@@ -99,3 +99,10 @@ LABEL	.print "THE END\n"
 
 	.include "namespace.s" namespace "oops"
 	.dw hello.oops.NamespaceMain, oops.NamespaceBonus
+
+.SECTION "DUMMY3" FREE
+DummyMain3:
+	nop
+	nop
+	nop
+.ENDS


### PR DESCRIPTION
Turns out I may have a use case for "appendto" after all. Seems cleaner to do it in the linkfile though!

I noticed while implementing this that APPENDTO has issues when there's a chain of length 3 or more. They need to be defined from first to last for it to work properly. Not sure how best to fix it. I'll make a separate issue.