### PR TITLE
Fix CMake build as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ foreach(ARCH IN LISTS ARCHS)
     endif()
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/op_tbl_gen/")
     set(TABLE_GEN_OUTPUT
-        "${CMAKE_BINARY_DIR}/op_tbl_gen/opcodes_${WLA_NAME}_tables.c")
+        "${CMAKE_CURRENT_BINARY_DIR}/op_tbl_gen/opcodes_${WLA_NAME}_tables.c")
     add_custom_command(
         OUTPUT "${TABLE_GEN_OUTPUT}"
         COMMAND ${GEN_PREFIX}gen-${WLA_NAME}
@@ -163,7 +163,7 @@ endforeach(ARCH)
 
 if(NOT CMAKE_CROSSCOMPILING)
     export(TARGETS ${GENERATOR_TARGETS}
-        FILE "${CMAKE_BINARY_DIR}/ImportGenerators.cmake"
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/ImportGenerators.cmake"
         NAMESPACE native-
         )
 endif()


### PR DESCRIPTION
I am embedding wla-dx into the source tree of my build, and I figured out that CMake wasn't building. This is because some of the locations of generated files are coded to CMAKE_BINARY_DIR, when they should be CMAKE_CURRENT_BINARY_DIR.

This PR should fix the issue. It builds correctly on my machine, hoping Azure works as well.