### PR TITLE
Explicit casts for MSVC warnings on implicit narrowing

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -45,9 +45,9 @@ int create_full_name(char *dir, char *name) {
   /* compute the length of the new string */
   i = 0;
   if (dir != NULL)
-    i += strlen(dir);
+    i += (int)strlen(dir);
   if (name != NULL)
-    i += strlen(name);
+    i += (int)strlen(name);
   i++;
 
   if (i > full_name_size) {
@@ -195,7 +195,7 @@ int include_file(char *name, int *include_size, char *namespace) {
     snprintf(change_file_buffer, sizeof(change_file_buffer), "%c.CHANGEFILE %d NONAMESPACE%c", 0xA, id, 0xA);
   else
     snprintf(change_file_buffer, sizeof(change_file_buffer), "%c.CHANGEFILE %d NAMESPACE %s%c", 0xA, id, namespace, 0xA);
-  change_file_buffer_size = strlen(change_file_buffer);
+  change_file_buffer_size = (int)strlen(change_file_buffer);
 
   /* reallocate buffer */
   if (include_in_tmp_size < file_size) {

--- a/main.c
+++ b/main.c
@@ -239,7 +239,7 @@ int parse_flags(char **flags, int flagc) {
       if (count + 1 < flagc) {
         if (count + 3 < flagc) {
           if (!strcmp(flags[count+2], "=")) {
-	    int length = strlen(flags[count+1])+strlen(flags[count+3])+2;
+	    int length = (int)strlen(flags[count+1])+(int)strlen(flags[count+3])+2;
             str_build = calloc(length, 1);
             snprintf(str_build, length, "%s=%s", flags[count+1], flags[count+3]);
             parse_and_add_definition(str_build, NO);
@@ -639,7 +639,7 @@ int parse_and_add_definition(char *c, int contains_flag) {
       s[t] = 0;
       
       if (*c == 0)
-        result = add_a_new_definition(n, 0.0, s, DEFINITION_TYPE_STRING, strlen(s));
+        result = add_a_new_definition(n, 0.0, s, DEFINITION_TYPE_STRING, (int)strlen(s));
       else {
         fprintf(stderr, "PARSE_AND_ADD_DEFINITION: Incorrectly terminated quoted string (%s).\n", value);
         result = FAILED;
@@ -650,7 +650,7 @@ int parse_and_add_definition(char *c, int contains_flag) {
     }
 
     /* unquoted string */
-    return add_a_new_definition(n, 0.0, c, DEFINITION_TYPE_STRING, strlen(c));
+    return add_a_new_definition(n, 0.0, c, DEFINITION_TYPE_STRING, (int)strlen(c));
   }
 
   return FAILED;

--- a/opcode_table_generator/main.c
+++ b/opcode_table_generator/main.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
   opcode_p[(int)b] = 0;
   while (opt_table[n].type != 0xff) {
     if (strlen(opt_table[n].op) > max) {
-      max = strlen(opt_table[n].op);
+      max = (unsigned int)strlen(opt_table[n].op);
       strcpy(max_name, opt_table[n].op);
     }
     if (opt_tmp[n].op[0] != a) {

--- a/pass_1.c
+++ b/pass_1.c
@@ -3786,7 +3786,7 @@ int directive_incdir(void) {
     return FAILED;
   }
 
-  q = strlen(label);
+  q = (int)strlen(label);
 
   /* use the default dir? */
   if (q == 0) {
@@ -3873,7 +3873,7 @@ int directive_include(int is_real) {
     }
 
     strcpy(&accumulated_name[accumulated_name_length], label);
-    accumulated_name_length = strlen(accumulated_name);
+    accumulated_name_length = (int)strlen(accumulated_name);
   }
 
   strcpy(path, accumulated_name);
@@ -9853,7 +9853,7 @@ int get_new_definition_data(int *b, char *c, int *size, double *data, int *expor
 
     if (x == INPUT_NUMBER_STRING) {
       strcpy(&c[s], label);
-      s += strlen(label);
+      s += (int)strlen(label);
     }
     else if (x == SUCCEEDED) {
       if (d > 255) {

--- a/wlab/main.c
+++ b/wlab/main.c
@@ -248,7 +248,7 @@ int parse_flags(char *f) {
     return FAILED;
   }
 
-  l = strlen(f);
+  l = (int)strlen(f);
   if (l == 1)
     return FAILED;
 

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -1367,7 +1367,7 @@ int write_symbol_file(char *outname, unsigned char mode, unsigned char outputAdd
   if (outname == NULL)
     return FAILED;
 
-  name_len = strlen(outname);
+  name_len = (unsigned int)strlen(outname);
   if (name_len > sizeof(name)-5) {
     fprintf(stderr, "WRITE_SYMBOL_FILE: File name too long.\n");
     return FAILED;


### PR DESCRIPTION
A stock load into Visual Studio 2019 as a CMake project gives a bunch of warnings on implicit narrowing assignments. This just adds explicit casts to all of them to get rid of the warnings.