### PR TITLE
Don't write defines to no$ style symbol files

### DIFF
--- a/doc/linking.rst
+++ b/doc/linking.rst
@@ -96,8 +96,8 @@ useful when you work under MSDOS (NO$GMB is a very good Game Boy emulator for
 MSDOS/Windows) as it contains information about the labels in your project.
 
 If flag ``S`` is used, WLALINK will create a WLA symbol file, that is much
-like NO$GMB symbol file, but shows also symbols and breakpoints, not just labels
-and definitions.
+like NO$GMB symbol file, but shows also symbols, defines, and breakpoints, not
+just labels.
 
 If flag ``d`` is used, WLALINK discards all unreferenced ``FREE``, ``SEMIFREE``,
 ``SEMISUBFREE``, ``SUPERFREE`` and ``RAM`` sections. This way you can link big

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -1403,7 +1403,7 @@ int write_symbol_file(char *outname, unsigned char mode, unsigned char outputAdd
 
     l = labels_first;
     while (l != NULL) {
-      if (l->alive == NO || is_label_anonymous(l->name) == YES || l->status == LABEL_STATUS_SYMBOL || l->status == LABEL_STATUS_BREAKPOINT) {
+      if (l->alive == NO || is_label_anonymous(l->name) == YES || l->status == LABEL_STATUS_SYMBOL || l->status == LABEL_STATUS_BREAKPOINT || l->status == LABEL_STATUS_DEFINE) {
 	l = l->next;
 	continue;
       }


### PR DESCRIPTION
I fail to see why defines should be included in nocash-style symbol files. This results in lines like this:

```
00:0008 _sizeof_sound58Channel2
```

This is very misleading because it looks like a label, but it is not, and there is no way to distinguish the two.

The motivation behind this PR is that neither style of symbol file (WLA or nocash) works with bgb as of version 1.5.8. Or rather, they may work, but all "_sizeof" definitions pollute the list of labels to the point of being unusable. (In my case it flat-out refused to load the file at all, for some reason, but it seems to have something to do with this.)

While it may be BGB's fault that it no longer loads WLA-style symbol files properly, writing defines to nocash-style symbol files seems wrong, as they are indistinguishable from labels, making the file useless for debugging - so that's on WLA.

The result of this change is that only labels with status "LABEL_STATUS_LABEL" or "LABEL_STATUS_STACK" are written to nocash-style symbol files (LABEL_STATUS_DEFINE is ignored). I'm not sure what "LABEL_STATUS_STACK" means so I didn't change that.