### PR TITLE
Fixed bad memory access & bug with addr-to-line mapping

### DIFF
--- a/wlalink/listfile.c
+++ b/wlalink/listfile.c
@@ -257,7 +257,7 @@ int listfile_write_listfiles(struct section *e) {
       while (m < n) {
 	if (b[m] == 0xA) {
 	  m++;
-	  if (b[m] == 0xD)
+	  if (m < n && b[m] == 0xD)
 	    m++;
 	  fprintf(f, "\n");
 	  break;

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -1613,7 +1613,7 @@ int write_symbol_file(char *outname, unsigned char mode, unsigned char outputAdd
           if (list_cmd == 'k') {
             /* new line */
             if (s->listfile_ints[list_cmd_idx * 3 + 1] > 0) {
-              fprintf(f, "%.2x:%.4x %.4x:%.8lx\n", s->bank + s->base, (s->output_address + list_address_offset) & 0xFFFF, list_source_file, (long unsigned int)s->listfile_ints[list_cmd_idx * 2 + 0]);
+              fprintf(f, "%.2x:%.4x %.4x:%.8lx\n", s->bank + s->base, (s->output_address + list_address_offset) & 0xFFFF, list_source_file, (long unsigned int)s->listfile_ints[list_cmd_idx * 3 + 0]);
               list_address_offset += s->listfile_ints[list_cmd_idx * 3 + 1];
             }
           }


### PR DESCRIPTION
The [addr-to-line] section in .sym files was entirely borked.