### PR TITLE
Add support for multiple include directories via the -I flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ ImportGenerators.cmake
 *.ilk
 *.ipdb
 *.iobj
+*.recipe

--- a/defines.h
+++ b/defines.h
@@ -541,6 +541,12 @@ struct section_def {
   struct section_def *next;
 };
 
+struct ext_include_collection {
+	int  count;
+	int  maxNameSizeBytes;
+	char** names;
+};
+
 struct incbin_file_data {
   struct incbin_file_data *next;
   char *data;


### PR DESCRIPTION
This change allows the command line parsing to support multiple uses of the -I flag, allowing for multiple include directories to be added.

When searching for includes, the old pattern of priorities applies (External > incdir > current), however the externals are now processed in order of inclusion on the command line.

It is backwards compatible with existing uses of the -I flag.

I required this change locally as I have a both an external code library and an external asset library that is shared between multiple projects. 