### PR TITLE
Improve include search error messages

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -86,6 +86,28 @@ int try_open_file(char* directory, char* partial_name, FILE** out_result) {
   return SUCCEEDED;
 }
 
+
+void print_include_search_error() {
+
+  int index;
+
+  fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
+  fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", full_name);
+
+  if (use_incdir == YES) {
+    for (index = 0; index < ext_incdirs.count; index++) {
+      fprintf(stderr, "%s\n", ext_incdirs.names[index]);
+    }
+  }
+
+  if (include_dir != NULL) {
+    fprintf(stderr, "%s\n", include_dir);
+  }
+
+  fprintf(stderr, "Current directory.\n");
+}
+
+
 int find_file(char *name, FILE** f) {
 
   int index;
@@ -111,23 +133,11 @@ int find_file(char *name, FILE** f) {
   if (*f != NULL)
     return SUCCEEDED;
 
-  fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
-  fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", full_name);
-
-  if (use_incdir == YES) {
-    for (index = 0; index < ext_incdirs.count; index++) {
-      fprintf(stderr, "%s\n", ext_incdirs.names[index]);
-    }
-  }
-
-  if (include_dir != NULL) {
-    fprintf(stderr, "%s\n", include_dir);
-  }
-
-  fprintf(stderr, "Current directory.\n");
+  print_include_search_error();
 
   return FAILED;
 }
+
 
 int include_file(char *name, int *include_size, char *namespace) {
 

--- a/include_file.c
+++ b/include_file.c
@@ -87,7 +87,7 @@ int try_open_file(char* directory, char* partial_name, FILE** out_result) {
 }
 
 
-void print_include_search_error(char* name) {
+static void print_find_error(char* name) {
 
   int index;
 
@@ -108,7 +108,7 @@ void print_include_search_error(char* name) {
 }
 
 
-int find_file(char *name, FILE** f) {
+static int find_file(char *name, FILE** f) {
 
   int index;
 
@@ -133,7 +133,7 @@ int find_file(char *name, FILE** f) {
   if (*f != NULL)
     return SUCCEEDED;
 
-  print_include_search_error(name);
+  print_find_error(name);
 
   return FAILED;
 }

--- a/include_file.c
+++ b/include_file.c
@@ -87,12 +87,12 @@ int try_open_file(char* directory, char* partial_name, FILE** out_result) {
 }
 
 
-void print_include_search_error() {
+void print_include_search_error(char* name) {
 
   int index;
 
   fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
-  fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", full_name);
+  fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", name);
 
   if (use_incdir == YES) {
     for (index = 0; index < ext_incdirs.count; index++) {
@@ -133,7 +133,7 @@ int find_file(char *name, FILE** f) {
   if (*f != NULL)
     return SUCCEEDED;
 
-  print_include_search_error();
+  print_include_search_error(name);
 
   return FAILED;
 }

--- a/include_file.c
+++ b/include_file.c
@@ -108,8 +108,21 @@ int find_file(char *name, FILE** f) {
   }
 
   if (*f == NULL) {
-    fprintf(stderr, "not found.\n");
-    fprintf(stderr, "FIND_FILE: Error opening file \"%s\".\n", name);
+    fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
+    fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", full_name);
+
+    if (use_incdir == YES) {
+      for (index = 0; index < ext_incdirs.count; index++) {
+        fprintf(stderr, "%s\n", ext_incdirs.names[index]);
+      }
+    }
+
+    if (include_dir != NULL) {
+      fprintf(stderr, "%s\n", include_dir);
+    }
+
+    fprintf(stderr, "Current directory.\n");
+
     return FAILED;
   }
   


### PR DESCRIPTION
Fixes #351 

## Issue

Currently when a included file isn't found in the first directory, the `include_file()` and `incbin_file()` functions output messagens even if the file is found. Example:

```
src/asm/main.asm:123: INCLUDE_FILE: Could not open "src/asm/src/data/foo.asm", trying "src/data/foo.asm"... found.
```

And even when the file isn't found, the error message isn't really helpful after @jwrayth contributiom for multiple include directories, because it only lists the last searched directory.

```
src/asm/main.asm:19: INCLUDE_FILE: Could not open "src/main/src/graphics/boxes.bin", trying "src/graphics/boxes.bin"... not found.
src/asm/main.asm:19: INCLUDE_FILE: Error opening file "src/main/src/graphics/boxes.bin".
src/asm/main.asm:19: ERROR: Couldn't parse ".INCBIN".
```

## Proposal

This PR updates both `include_file()` and `incbin_file()` to print the error message only after all directories have been search and the file could not be located. If the file is found in any of the included dirs, no output is printed.

In the case of a file not being found in any include folder, the user will receive a message listing all searched ones:

```
src/asm/main.asm:123: FIND_FILE: Could not open "src/graphics/boxes.bin", searched in the following directories:
src/
src/data/
Current directory.
src/asm/main.asm:123: ERROR: Couldn't parse ".INCBIN".
```

## Bonus
The file search code that was previously duplicated on both `include_file()` and `incbin_file()` was extracted to a separedted function. Some other simple refactoring was done to improve maintenance of the source code.
The result is actually less code than at the moment.

## Warning
Please review carefully my changes because I'm still learning C programming :)