### PR TITLE
Fix segmentation fault when input file cannot be found

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -91,6 +91,11 @@ static void print_find_error(char* name) {
 
   int index;
 
+  if (!active_file_info_last) {
+    fprintf(stderr, "FIND_FILE: Could not open \"%s\".", name);
+    return;
+  }
+
   fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
   fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", name);
 

--- a/include_file.c
+++ b/include_file.c
@@ -91,12 +91,9 @@ static void print_find_error(char* name) {
 
   int index;
 
-  if (!active_file_info_last) {
-    fprintf(stderr, "FIND_FILE: Could not open \"%s\".", name);
-    return;
-  }
+  if (active_file_info_last)
+    fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
 
-  fprintf(stderr, "%s:%d: ", get_file_name(active_file_info_last->filename_id), active_file_info_last->line_current);
   fprintf(stderr, "FIND_FILE: Could not open \"%s\", searched in the following directories:\n", name);
 
   if (use_incdir == YES) {


### PR DESCRIPTION
Recent changes introduced a segfault when the input file can't be found.

```
wla-z80 -o out.o wrongfile.asm
Segmentation fault (core dumped)
```

This happens because the `print_find_error()` function tries to print the active file name and line where the error occurred, from `active_file_info_last` struct, but it still NULL when the input file is searched:

https://github.com/vhelin/wla-dx/blob/ef508e4b302d5be62c95595b5d6b30edfdc14342/include_file.c#L90-L96

This PR fixes it by simply adding a condition to check if there is a active file before trying to print it's name and line.