### PR TITLE
Refactor argument flags parsing

### DIFF
--- a/main.c
+++ b/main.c
@@ -207,6 +207,22 @@ int main(int argc, char *argv[]) {
   return 0;
 }
 
+static int parse_output_flag(char **flags, int flagc, int *count) {
+  if (output_format != OUTPUT_NONE)
+    return FAILED;
+  output_format = OUTPUT_OBJECT;
+  if (*count + 1 < flagc) {
+    /* set output */
+    final_name = calloc(strlen(flags[*count+1])+1, 1);
+    strcpy(final_name, flags[*count+1]);
+  }
+  else
+    return FAILED;
+  
+  (*count)++;
+  return SUCCEEDED;
+}
+
 int parse_flags(char **flags, int flagc) {
   int asm_name_def = 0, count;
   char *str_build;
@@ -218,18 +234,8 @@ int parse_flags(char **flags, int flagc) {
 
     switch (flags[count][1]) {
       case 'o':
-        if (output_format != OUTPUT_NONE)
+        if (parse_output_flag(flags, flagc, &count) != SUCCEEDED)
           return FAILED;
-        output_format = OUTPUT_OBJECT;
-        if (count + 1 < flagc) {
-          /* set output */
-          final_name = calloc(strlen(flags[count+1])+1, 1);
-          strcpy(final_name, flags[count+1]);
-        }
-        else
-          return FAILED;
-
-        count++;
         break;
 
       case 'l':

--- a/main.c
+++ b/main.c
@@ -345,23 +345,20 @@ static int parse_flag(char **flags, int flagc, int *count)
 }
 
 int parse_flags(char **flags, int flagc) {
-  int count;
+  int count = 1;
   
-  for (count = 1; count < flagc; count++) {
-    if (flags[count][0] == '-') {
-      if (parse_flag(flags, flagc, &count) != SUCCEEDED)
-        return FAILED;
-    } else {
-      if (count != flagc - 1) {
-        return FAILED;
-      }
+  while (count < flagc && flags[count][0] == '-') {
+    if (parse_flag(flags, flagc, &count) != SUCCEEDED)
+      return FAILED;
 
-      asm_name = calloc(strlen(flags[count - 1]) + 1, 1);
-      strcpy(asm_name, flags[count]);
-
-      break;
-    }
+    count++;
   }
+
+  if (count != flagc - 1)
+    return FAILED;
+
+  asm_name = calloc(strlen(flags[count - 1]) + 1, 1);
+  strcpy(asm_name, flags[count]);
   
   return SUCCEEDED;
 }

--- a/main.c
+++ b/main.c
@@ -270,7 +270,7 @@ static int parse_define_flag(char **flags, int flagc, int *count) {
 }
 
 int parse_flags(char **flags, int flagc) {
-  int asm_name_def = 0, count;
+  int count;
   
   for (count = 1; count < flagc; count++) {
     if (flags[count][0] != '-') {
@@ -348,14 +348,9 @@ int parse_flags(char **flags, int flagc) {
   if (count == flagc) {
     asm_name = calloc(strlen(flags[count - 1]) + 1, 1);
     strcpy(asm_name, flags[count - 1]);
-    count++;
-    asm_name_def++;
   } else {
     return FAILED;
   }
-  
-  if (asm_name_def <= 0)
-    return FAILED;
   
   return SUCCEEDED;
 }

--- a/main.c
+++ b/main.c
@@ -282,77 +282,85 @@ static int parse_include_flag(char **flags, int flagc, int *count) {
   return SUCCEEDED;
 }
 
+static int parse_flag(char **flags, int flagc, int *count)
+{
+  switch (flags[*count][1]) {
+    case 'o':
+      if (parse_output_object_flag(flags, flagc, count) != SUCCEEDED)
+        return FAILED;
+      break;
+
+    case 'l':
+      if (parse_output_library_flag(flags, flagc, count) != SUCCEEDED)
+        return FAILED;
+      break;
+
+    case 'D':
+      if (parse_define_flag(flags, flagc, count) != SUCCEEDED)
+        return FAILED;
+      break;
+
+    case 'I':
+      if (parse_include_flag(flags, flagc, count) != SUCCEEDED)
+        return FAILED;
+      break;
+
+    case 'i':
+      listfile_data = YES;
+      break;
+
+    case 'v':
+      verbose_mode = ON;
+      break;
+
+    case 's':
+      create_sizeof_definitions = NO;
+      break;
+
+    case 't':
+      test_mode = ON;
+      break;
+
+    case 'M':
+      makefile_rules = YES;
+      test_mode = ON;
+      verbose_mode = OFF;
+      quiet = YES;
+      break;
+
+    case 'q':
+      quiet = YES;
+      break;
+
+    case 'x':
+      extra_definitions = ON;
+      break;
+
+    default:
+      return FAILED;
+      break;
+  }
+
+  return SUCCEEDED;
+}
+
 int parse_flags(char **flags, int flagc) {
   int count;
   
   for (count = 1; count < flagc; count++) {
-    if (flags[count][0] != '-') {
-      continue;
-    }
-
-    switch (flags[count][1]) {
-      case 'o':
-        if (parse_output_object_flag(flags, flagc, &count) != SUCCEEDED)
-          return FAILED;
-        break;
-
-      case 'l':
-        if (parse_output_library_flag(flags, flagc, &count) != SUCCEEDED)
-          return FAILED;
-        break;
-
-      case 'D':
-        if (parse_define_flag(flags, flagc, &count) != SUCCEEDED)
-          return FAILED;
-        break;
-
-      case 'I':
-        if (parse_include_flag(flags, flagc, &count) != SUCCEEDED)
-          return FAILED;
-        break;
-
-      case 'i':
-        listfile_data = YES;
-        break;
-
-      case 'v':
-        verbose_mode = ON;
-        break;
-
-      case 's':
-        create_sizeof_definitions = NO;
-        break;
-
-      case 't':
-        test_mode = ON;
-        break;
-
-      case 'M':
-        makefile_rules = YES;
-        test_mode = ON;
-        verbose_mode = OFF;
-        quiet = YES;
-        break;
-
-      case 'q':
-        quiet = YES;
-        break;
-
-      case 'x':
-        extra_definitions = ON;
-        break;
-
-      default:
+    if (flags[count][0] == '-') {
+      if (parse_flag(flags, flagc, &count) != SUCCEEDED)
         return FAILED;
-        break;
-    }
-  }
+    } else {
+      if (count != flagc - 1) {
+        return FAILED;
+      }
 
-  if (count == flagc) {
-    asm_name = calloc(strlen(flags[count - 1]) + 1, 1);
-    strcpy(asm_name, flags[count - 1]);
-  } else {
-    return FAILED;
+      asm_name = calloc(strlen(flags[count - 1]) + 1, 1);
+      strcpy(asm_name, flags[count]);
+
+      break;
+    }
   }
   
   return SUCCEEDED;

--- a/main.c
+++ b/main.c
@@ -253,6 +253,8 @@ static int parse_define_flag(char **flags, int flagc, int *count) {
     }
     else
       parse_and_add_definition(flags[*count+1], NO);
+    
+    (*count)++;
   }
   /* Legacy define */
   else if (flags[*count][2]) {
@@ -261,7 +263,6 @@ static int parse_define_flag(char **flags, int flagc, int *count) {
   else
     return FAILED;
 
-  (*count)++;
   return SUCCEEDED;
 }
 
@@ -269,6 +270,7 @@ static int parse_include_flag(char **flags, int flagc, int *count) {
   if (!flags[*count][2] && *count + 1 < flagc) {
     /* get arg */
     parse_and_add_incdir(flags[*count+1], NO);
+    (*count)++;
   }
   /* Legacy include */
   else if (flags[*count][2]) {
@@ -277,7 +279,6 @@ static int parse_include_flag(char **flags, int flagc, int *count) {
   else
     return FAILED;
 
-  (*count)++;
   return SUCCEEDED;
 }
 

--- a/main.c
+++ b/main.c
@@ -269,6 +269,22 @@ static int parse_define_flag(char **flags, int flagc, int *count) {
   return SUCCEEDED;
 }
 
+static int parse_include_flag(char **flags, int flagc, int *count) {
+  if (!flags[*count][2] && *count + 1 < flagc) {
+    /* get arg */
+    parse_and_add_incdir(flags[*count+1], NO);
+  }
+  /* Legacy include */
+  else if (flags[*count][2]) {
+    parse_and_add_incdir(flags[*count], YES);
+  }
+  else
+    return FAILED;
+
+  (*count)++;
+  return SUCCEEDED;
+}
+
 int parse_flags(char **flags, int flagc) {
   int count;
   
@@ -294,18 +310,8 @@ int parse_flags(char **flags, int flagc) {
         break;
 
       case 'I':
-        if (!flags[count][2] && count + 1 < flagc) {
-          /* get arg */
-          parse_and_add_incdir(flags[count+1], NO);
-        }
-        /* Legacy include */
-        else if (flags[count][2]) {
-          parse_and_add_incdir(flags[count], YES);
-        }
-        else
+        if (parse_include_flag(flags, flagc, &count) != SUCCEEDED)
           return FAILED;
-
-        count++;
         break;
 
       case 'i':

--- a/main.c
+++ b/main.c
@@ -282,8 +282,7 @@ static int parse_include_flag(char **flags, int flagc, int *count) {
   return SUCCEEDED;
 }
 
-static int parse_flag(char **flags, int flagc, int *count)
-{
+static int parse_flag(char **flags, int flagc, int *count) {
   switch (flags[*count][1]) {
     case 'o':
       if (parse_output_object_flag(flags, flagc, count) != SUCCEEDED)
@@ -343,6 +342,7 @@ static int parse_flag(char **flags, int flagc, int *count)
 
   return SUCCEEDED;
 }
+
 
 int parse_flags(char **flags, int flagc) {
   int count = 1;

--- a/main.c
+++ b/main.c
@@ -243,17 +243,13 @@ static int parse_define_flag(char **flags, int flagc, int *count) {
   char *str_build;
 
   if (!flags[*count][2] && *count + 1 < flagc) {
-    if (*count + 3 < flagc) {
-      if (!strcmp(flags[*count+2], "=")) {
-        int length = (int)strlen(flags[*count+1])+(int)strlen(flags[*count+3])+2;
-        str_build = calloc(length, 1);
-        snprintf(str_build, length, "%s=%s", flags[*count+1], flags[*count+3]);
-        parse_and_add_definition(str_build, NO);
-        free(str_build);
-        *count += 2;
-      }
-      else
-        parse_and_add_definition(flags[*count+1], NO);
+    if (*count + 3 < flagc && !strcmp(flags[*count+2], "=")) {
+      int length = (int)strlen(flags[*count+1])+(int)strlen(flags[*count+3])+2;
+      str_build = calloc(length, 1);
+      snprintf(str_build, length, "%s=%s", flags[*count+1], flags[*count+3]);
+      parse_and_add_definition(str_build, NO);
+      free(str_build);
+      *count += 2;
     }
     else
       parse_and_add_definition(flags[*count+1], NO);


### PR DESCRIPTION
Refactor parse_flags function, making it easier to understand and maintain.

Changes:
- Use `flags[count][1] == 'f'` instead of `strcmp(flags[count], "-f")`
- Use a switch case instead of a if statement
- Extract complex specific flag handling logic to it own static functions (include, define, output)
- Use a while loop to iterate over all flags
- Removed some code and variables that proved to be unnecessary

## Statistics
Function average Cyclomatic Complexity of main.c dropped from 15.2 to 10.6 (-30%).
Function average lines of code count (without comments) of main.c dropped from 59.3 to 38.4 (-35%).

*Unchanged functions were ommited for brevity.*

**Before:**
```
 NLOC  Avg.NLOC  AvgCCN   Avg.token  function_cnt    file
--------------------------------------------------------------
  591      59.3    15.2      401.2              9    main.c

================================================
  NLOC    CCN    token  PARAM  length  location  
------------------------------------------------
   117     25      700      2     131  parse_flags@211-341@main.c
```

**After:**
```
 NLOC  Avg.NLOC  AvgCCN  Avg.token  function_cnt    file
--------------------------------------------------------------
  595      38.4    10.6      261.6            14    main.c

  NLOC    CCN   Token  Param  Length  Location  
------------------------------------------------
    13      3      85      3      15  parse_output_object_flag@210-224@main.c
    13      3      85      3      15  parse_output_library_flag@226-240@main.c
    22      6     201      3      26  parse_define_flag@242-267@main.c
    12      4      87      3      15  parse_include_flag@269-283@main.c
    48     16     197      3      60  parse_flag@285-344@main.c
    13      5      97      2      18  parse_flags@347-364@main.c
```
