### PR TITLE
Incbin fix

### DIFF
--- a/include_file.c
+++ b/include_file.c
@@ -13,10 +13,11 @@
 #include "printf.h"
 
 
-extern int g_ind, g_source_pointer, g_extra_definitions, g_parsed_int, g_use_incdir;
+extern int g_ind, g_source_pointer, g_extra_definitions, g_parsed_int, g_use_incdir, g_makefile_rules;
 extern char g_tmp[4096], g_error_message[sizeof(g_tmp) + MAX_NAME_LENGTH + 1 + 1024];
 extern struct ext_include_collection g_ext_incdirs;
 extern FILE *g_file_out_ptr;
+extern int generate_tmp_name(char **filename);
 
 struct incbin_file_data *g_incbin_file_data_first = NULL, *g_ifd_tmp;
 struct active_file_info *g_active_file_info_first = NULL, *g_active_file_info_last = NULL, *g_active_file_info_tmp = NULL;
@@ -135,6 +136,17 @@ static int find_file(char *name, FILE** f) {
   if (*f != NULL)
     return SUCCEEDED;
 
+  /* if we can't find the file, but are only printing makefile rules, silently use an empty file */
+  /* a warning might be nice */
+  if (g_makefile_rules == YES) {
+    if (generate_tmp_name(&name) == SUCCEEDED) {
+      fclose(fopen(name, "wb"));
+      (*f) = fopen(name, "rb");
+      if (*f != NULL)
+        return SUCCEEDED;
+    }
+  }
+  
   print_find_error(name);
 
   return FAILED;

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -953,7 +953,7 @@ int parse_and_set_libdir(char *c, int contains_flag) {
 
   localize_path(n);
 #if defined(MSDOS)
-  snprintf(ext_libdir, sizeof(ext_libdir), "%s\\", n);
+  snprintf(g_ext_libdir, sizeof(g_ext_libdir), "%s\\", n);
 #else
   snprintf(g_ext_libdir, sizeof(g_ext_libdir), "%s/", n);
 #endif


### PR DESCRIPTION
Fixes issue #319, and a minor build issue in DOS/Windows environments.

This makes PR #321 half redundant, but it was Unix only, and the function signature has changed.

Tests pass, and my code now compiles whenever I add a new file.

As a side effect, builds succeed even if an `.INCLUDE` directive was used, generating potentially incomplete Makefile rules.
Depending on the structure of the Makefile, this may miss some dependencies in chained-include cases:
File A includes file B, which includes file C, but file B doesn't exist yet. Therefore, A depends on C, but the generated rule would neglect this. The rule generated for B wouldn't, though.