### PR TITLE
Wrong variable used as path index causes segfault, see #384

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -1357,8 +1357,8 @@ int localize_path(char *path) {
   for (i = 0; path[i] != 0; i++) {
 #if defined(MSDOS)
     /* '/' -> '\' */
-    if (path[g_source_pointer] == '/')
-      path[g_source_pointer] = '\\';
+    if (path[i] == '/')
+      path[i] = '\\';
 #else
     /* '\' -> '/' */
     if (path[i] == '\\')


### PR DESCRIPTION
Recent refactoring of locals vs. globals missed some code behind `#if defined(MSDOS)` guards. 