### PR TITLE
Use automatic dependency tracking on MS-DOS makefiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.md    text
 *.sh    text eol=lf
 *.bat   text eol=crlf
+makefile.msdos.*    text eol=crlf
 
 # bat-files usually works with LF, but Windows users might have a better
 # editing time with notepad and CRLF, because nodepad is dumb with LF

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ wla_[ab].tmp
 *.so
 *.a
 *.exe
+*.d
 
 # Generated files
 opcodes_*_tables.c

--- a/historical/makefiles/makefile.msdos.6502
+++ b/historical/makefiles/makefile.msdos.6502
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6502
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6502 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6502_tables.c opcodes_6502.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6502_tables.o opcodes_6502.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_6502_tables.o opcodes_6502.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6502.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-6502.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6502_tables.o: opcodes_6502_tables.c
-	$(CC) $(CFLAGS) opcodes_6502_tables.c
-
-opcodes_6502.o: opcodes_6502.c
-	$(CC) $(CFLAGS) opcodes_6502.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-6502.exe
+	del *.o ; del *.d ; del *~ ; del wla-6502.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.6510
+++ b/historical/makefiles/makefile.msdos.6510
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6510
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6510 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6510_tables.c opcodes_6510.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6510_tables.o opcodes_6510.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_6510_tables.o opcodes_6510.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6510.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-6510.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6510_tables.o: opcodes_6510_tables.c
-	$(CC) $(CFLAGS) opcodes_6510_tables.c
-
-opcodes_6510.o: opcodes_6510.c
-	$(CC) $(CFLAGS) opcodes_6510.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-6510.exe
+	del *.o ; del *.d ; del *~ ; del wla-6510.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.65816
+++ b/historical/makefiles/makefile.msdos.65816
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DW65816
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DW65816 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65816_tables.c opcodes_65816.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65816_tables.o opcodes_65816.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_65816_tables.o opcodes_65816.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65816.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-65816.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65816_tables.o: opcodes_65816_tables.c
-	$(CC) $(CFLAGS) opcodes_65816_tables.c
-
-opcodes_65816.o: opcodes_65816.c
-	$(CC) $(CFLAGS) opcodes_65816.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-65816.exe
+	del *.o ; del *.d ; del *~ ; del wla-65816.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.65c02
+++ b/historical/makefiles/makefile.msdos.65c02
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DWDC65C02
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DWDC65C02 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65c02_tables.c opcodes_65c02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65c02_tables.o opcodes_65c02.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_65c02_tables.o opcodes_65c02.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65c02.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-65c02.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65c02_tables.o: opcodes_65c02_tables.c
-	$(CC) $(CFLAGS) opcodes_65c02_tables.c
-
-opcodes_65c02.o: opcodes_65c02.c
-	$(CC) $(CFLAGS) opcodes_65c02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-65c02.exe
+	del *.o ; del *.d ; del *~ ; del wla-65c02.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.65ce02
+++ b/historical/makefiles/makefile.msdos.65ce02
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DCSG65CE02
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DCSG65CE02 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65ce02_tables.c opcodes_65ce02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65ce02_tables.o opcodes_65ce02.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_65ce02_tables.o opcodes_65ce02.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65ce02.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-65ce02.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65ce02_tables.o: opcodes_65ce02_tables.c
-	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
-
-opcodes_65ce02.o: opcodes_65ce02.c
-	$(CC) $(CFLAGS) opcodes_65ce02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-65ce02.exe
+	del *.o ; del *.d ; del *~ ; del wla-65ce02.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.6800
+++ b/historical/makefiles/makefile.msdos.6800
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6800
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6800 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6800_tables.c opcodes_6800.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6800_tables.o opcodes_6800.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_6800_tables.o opcodes_6800.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6800.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-6800.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6800_tables.o: opcodes_6800_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6800_tables.c
-
-opcodes_6800.o: opcodes_6800.c
-	$(CC) $(WLAFLAGS) opcodes_6800.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-6800.exe
+	del *.o ; del *.d ; del *~ ; del wla-6800.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.6801
+++ b/historical/makefiles/makefile.msdos.6801
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6801
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6801 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6801_tables.c opcodes_6801.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6801_tables.o opcodes_6801.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_6801_tables.o opcodes_6801.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6801.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-6801.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6801_tables.o: opcodes_6801_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6801_tables.c
-
-opcodes_6801.o: opcodes_6801.c
-	$(CC) $(WLAFLAGS) opcodes_6801.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-6801.exe
+	del *.o ; del *.d ; del *~ ; del wla-6801.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.6809
+++ b/historical/makefiles/makefile.msdos.6809
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6809
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6809 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6809_tables.c opcodes_6809.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6809_tables.o opcodes_6809.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_6809_tables.o opcodes_6809.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6809.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-6809.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6809_tables.o: opcodes_6809_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6809_tables.c
-
-opcodes_6809.o: opcodes_6809.c
-	$(CC) $(WLAFLAGS) opcodes_6809.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-6809.exe
+	del *.o ; del *.d ; del *~ ; del wla-6809.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.8008
+++ b/historical/makefiles/makefile.msdos.8008
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8008
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8008 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8008_tables.c opcodes_8008.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8008_tables.o opcodes_8008.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_8008_tables.o opcodes_8008.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-8008.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-8008.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8008_tables.o: opcodes_8008_tables.c
-	$(CC) $(CFLAGS) opcodes_8008_tables.c
-
-opcodes_8008.o: opcodes_8008.c
-	$(CC) $(CFLAGS) opcodes_8008.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-8008.exe
+	del *.o ; del *.d ; del *~ ; del wla-8008.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.8080
+++ b/historical/makefiles/makefile.msdos.8080
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8080
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8080 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8080_tables.c opcodes_8080.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8080_tables.o opcodes_8080.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_8080_tables.o opcodes_8080.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-8080.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-8080.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8080_tables.o: opcodes_8080_tables.c
-	$(CC) $(CFLAGS) opcodes_8080_tables.c
-
-opcodes_8080.o: opcodes_8080.c
-	$(CC) $(CFLAGS) opcodes_8080.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-8080.exe
+	del *.o ; del *.d ; del *~ ; del wla-8080.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.gb
+++ b/historical/makefiles/makefile.msdos.gb
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DGB
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DGB -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_gb_tables.c opcodes_gb.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_gb_tables.o opcodes_gb.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_gb_tables.o opcodes_gb.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-gb.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-gb.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_gb_tables.o: opcodes_gb_tables.c
-	$(CC) $(CFLAGS) opcodes_gb_tables.c
-
-opcodes_gb.o: opcodes_gb.c
-	$(CC) $(CFLAGS) opcodes_gb.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-gb.exe
+	del *.o ; del *.d ; del *~ ; del wla-gb.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.huc6280
+++ b/historical/makefiles/makefile.msdos.huc6280
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DHUC6280
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DHUC6280 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_huc6280_tables.c opcodes_huc6280.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_huc6280_tables.o opcodes_huc6280.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_huc6280_tables.o opcodes_huc6280.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-huc6280.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-huc6280.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_huc6280_tables.o: opcodes_huc6280_tables.c
-	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
-
-opcodes_huc6280.o: opcodes_huc6280.c
-	$(CC) $(CFLAGS) opcodes_huc6280.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-huc6280.exe
+	del *.o ; del *.d ; del *~ ; del wla-huc6280.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.spc700
+++ b/historical/makefiles/makefile.msdos.spc700
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DSPC700
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DSPC700 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_spc700_tables.c opcodes_spc700.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_spc700_tables.o opcodes_spc700.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_spc700_tables.o opcodes_spc700.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-spc700.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-spc700.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_spc700_tables.o: opcodes_spc700_tables.c
-	$(CC) $(CFLAGS) opcodes_spc700_tables.c
-
-opcodes_spc700.o: opcodes_spc700.c
-	$(CC) $(CFLAGS) opcodes_spc700.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-spc700.exe
+	del *.o ; del *.d ; del *~ ; del wla-spc700.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/makefiles/makefile.msdos.z80
+++ b/historical/makefiles/makefile.msdos.z80
@@ -1,65 +1,22 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DZ80
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DZ80 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
 WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_z80_tables.c opcodes_z80.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_z80_tables.o opcodes_z80.o
+OFILES = main.o crc32.o hashmap.o include_file.o listfile.o mersenne_twister.o parse.o pass_1.o pass_2.o pass_3.o pass_4.o printf.o stack.o opcodes_z80_tables.o opcodes_z80.o
 
+DEPS := $(patsubst %.o,%.d,$(OFILES))
 
-all: $(OFILES) makefile
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-z80.exe
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $^ -o wla-z80.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_z80_tables.o: opcodes_z80_tables.c
-	$(CC) $(CFLAGS) opcodes_z80_tables.c
-
-opcodes_z80.o: opcodes_z80.c
-	$(CC) $(CFLAGS) opcodes_z80.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
-
+%.o: %.c
+	$(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
 
 clean:
-	del *.o ; del *~ ; del wla-z80.exe
+	del *.o ; del *.d ; del *~ ; del wla-z80.exe
+
+# Include the .d makefiles
+-include $(DEPS)

--- a/historical/wlab/makefile.msdos
+++ b/historical/wlab/makefile.msdos
@@ -1,6 +1,6 @@
 
 CC = gcc
-CFLAGS = -m486 -c -ansi -O3 -pedantic -Wall
+CFLAGS = -mtune=i486 -c -ansi -O3 -pedantic -Wall -DNDEBUG=1
 LD = gcc
 LDFLAGS = 
 

--- a/historical/wlad/makefile.msdos
+++ b/historical/wlad/makefile.msdos
@@ -1,6 +1,6 @@
 
 CC = gcc
-CFLAGS = -m486 -c -ansi -O3 -pedantic -Wall -DMSDOS -DGB
+CFLAGS = -mtune=i486 -c -ansi -O3 -pedantic -Wall -DMSDOS -DGB -DNDEBUG=1
 LD = gcc
 LDFLAGS = 
 

--- a/historical/wlalink/makefile.msdos
+++ b/historical/wlalink/makefile.msdos
@@ -1,6 +1,6 @@
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DNDEBUG=1
 LD = gcc
 LDFLAGS =
 

--- a/printf.c
+++ b/printf.c
@@ -32,7 +32,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 */
 
-#ifdef AMIGA
+#if defined(AMIGA) || defined(MSDOS)
 typedef unsigned long uintptr_t;
 typedef long intmax_t;
 #define PRINTF_DISABLE_SUPPORT_LONG_LONG 1


### PR DESCRIPTION
## Intro

If accepted, this pull request will update MS-DOS makefiles adding automatic dependency tracking.
Additionally, it removes the `-m` flag (removed from gcc) in favor or `-mtune`. It also defines `NDEBUG` so we have release builds as default.

Following https://github.com/vhelin/wla-dx/issues/364#issuecomment-774841557, I was able to *successfully* build WLA 6502, 6510, 6800, 6801, 6809, 8008, 8080, gb and z80.
As before, 65816, 65c02, 65ce02, huc6280, spc700 were not built. I suspect that the target name length plays a role here as all of them result in a .exe that does not comply with the DOS 8dot3 filename limit. Further analysis is needed.

The makefiles were re-generated with a Python script. We can do the same for Amiga make/smake ones allowing #356 to proceed.

## Details

### Pattern Rules

The first step was to use just one Pattern Rule for all object dependencies, so instead of:

```makefile
all: $(OFILES) makefile
    $(LD) $(LDFLAGS) $(OFILES) -o wla-z80.exe

main.o: main.c defines.h main.h makefile
    $(CC) $(CFLAGS) main.c

printf.o: printf.c printf.h makefile
    $(CC) $(CFLAGS) printf.c

# rules omitted for brevity ...
```
We use:

```makefile
all: $(OFILES)
    $(LD) $(LDFLAGS) $^ -o wla-z80.exe

%.o: %.c
    $(CC) $(CFLAGS) $<

# "$<" means first prerequisite name
# "$^" means all prerequisites
```
The `makefile` prerequisite isn't needed and was removed.

Note that headers were removed from the prerequisites, as gcc will generate this for us below.

### -MMD -MF

By passing `-MMD -MF` options, we ask gcc to output the dependencies of the current source in makefile format to a file.

```makefile
# stack.d

stack.o: stack.c defines.h hashmap.h shared.h parse.h pass_1.h stack.h \
 include_file.h printf.h
```

Instead of manually typing (and tracking), we can just include those *.d makefiles.

So, we add `-MMD and -MF <target>.d` to our Pattern Rule:
```makefile
# "@" gets replaced by the target name.
# ".o=.d" replaces the .o extension with .d

%.o: %.c
    $(CC) $(CFLAGS) $< -MMD -MF $(@:.o=.d)
```

The effective rule for a given object is the following:

```makefile
# This is just a demonstration of the effective rule for the
# main.o target, and is not present on the makefile itself.

stack.o: stack.c
    $(CC) $(CFLAGS) stack.c -MMD -MF stack.d  
```

Instead of including each .d makefile, i'm using a little trick to include all of them:
(See the referenced links for more info)
```makefile
-include($(patsubst %.o,%.d,$(OFILES)))
```
Note that a "-" is used before the include to suppress errors, as there are no *.d files to include on the first run.
This isn't a problem because they're useful only when rebuilding objects after changing files during development.

## Dependency graph
Before:
![Before](https://user-images.githubusercontent.com/7695608/106103802-45a1a000-6120-11eb-948a-c45841d80f62.png)
After:
![After](https://user-images.githubusercontent.com/7695608/111895973-0c393280-89f5-11eb-97fc-30676461f27e.png)


## References
[Makefile Tutorial - Advanced | Automatic Dependency Tracking, Variables, and Pattern Rules](https://www.youtube.com/watch?v=PiFUuQqW-v8)
[Makefile Tutorial By Example](https://makefiletutorial.com)