### PR TITLE
Add historical makefile generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.md    text
 *.sh    text eol=lf
 *.bat   text eol=crlf
+makefile.msdos.*    text eol=crlf
 
 # bat-files usually works with LF, but Windows users might have a better
 # editing time with notepad and CRLF, because nodepad is dumb with LF

--- a/historical/makefile_generator/gen.py
+++ b/historical/makefile_generator/gen.py
@@ -25,6 +25,13 @@ cpus = [
     {'name': 'z80', 'define': 'Z80'}
 ]
 
+warning = [
+    '###################################################',
+    '# WARNING: This file was automatically generated. #',
+    '###################################################',
+    '',
+]
+
 # First we instantiate a new Template for each platform.
 # For now, only MS-DOS is being generated.
 msdos_stub = open('makefile.msdos.template')
@@ -182,5 +189,5 @@ for cpu in cpus:
         os.mkdir(output_folder)
 
     f = open(output_folder + '/makefile.msdos.' + cpu['name'], "w")
-    f.write(msdos_out)
+    f.write('\r\n'.join(warning) + msdos_out)
     f.close()

--- a/historical/makefile_generator/gen.py
+++ b/historical/makefile_generator/gen.py
@@ -27,7 +27,7 @@ cpus = [
 
 # First we instantiate a new Template for each platform.
 # For now, only MS-DOS is being generated.
-msdos_stub = open('msdos.template')
+msdos_stub = open('makefile.msdos.template')
 msdos_stub_contents = msdos_stub.read()
 msdos_stub.close()
 msdos_template = MyTemplate(msdos_stub_contents)

--- a/historical/makefile_generator/gen.py
+++ b/historical/makefile_generator/gen.py
@@ -45,6 +45,11 @@ def main():
     amiga_stub.close()
     amiga_template = MyTemplate(amiga_stub_contents)
 
+    smake_stub = open('makefile.smake.template')
+    smake_stub_contents = smake_stub.read()
+    smake_stub.close()
+    smake_template = MyTemplate(smake_stub_contents)
+
     # Create output directory if necessary
     if not os.path.exists(output_folder):
         print('Created output directory: ' + output_folder)
@@ -53,6 +58,7 @@ def main():
     for cpu in cpus:
         msdos = generate(cpu, '\r\n', msdos_template)
         amiga = generate(cpu, '\n', amiga_template)
+        smake = generate(cpu, '\n', smake_template)
 
         f = open(output_folder + '/makefile.msdos.' + cpu['name'], "w")
         f.write(msdos)
@@ -60,6 +66,10 @@ def main():
 
         f = open(output_folder + '/makefile.amiga.' + cpu['name'], "w")
         f.write(amiga)
+        f.close()
+
+        f = open(output_folder + '/smake.' + cpu['name'], "w")
+        f.write(smake)
         f.close()
     
     print('Makefiles successfully generated!')

--- a/historical/makefile_generator/gen.py
+++ b/historical/makefile_generator/gen.py
@@ -1,0 +1,186 @@
+from string import Template
+import os
+import re
+
+output_folder = '../makefiles'
+
+# Our templates use "@" as delimiter
+class MyTemplate(Template):
+    delimiter = "@"
+
+cpus = [
+    {'name': '6502', 'define': 'MCS6502'},
+    {'name': '6510', 'define': 'MCS6510'},
+    {'name': '65816', 'define': 'W65816'},
+    {'name': '65c02', 'define': 'WDC65C02'},
+    {'name': '65ce02', 'define': 'CSG65CE02'},
+    {'name': '6800', 'define': 'MC6800'},
+    {'name': '6801', 'define': 'MC6801'},
+    {'name': '6809', 'define': 'MC6809'},
+    {'name': '8008', 'define': 'I8008'},
+    {'name': '8080', 'define': 'I8080'},
+    {'name': 'gb', 'define': 'GB'},
+    {'name': 'huc6280', 'define': 'HUC6280'},
+    {'name': 'spc700', 'define': 'SPC700'},
+    {'name': 'z80', 'define': 'Z80'}
+]
+
+# First we instantiate a new Template for each platform.
+# For now, only MS-DOS is being generated.
+msdos_stub = open('msdos.template')
+msdos_stub_contents = msdos_stub.read()
+msdos_stub.close()
+msdos_template = MyTemplate(msdos_stub_contents)
+
+# Then, we start generating makefiles for each CPU that WLA can assemble.
+for cpu in cpus:
+    # Here we have a dictionary where each item represents a C source file.
+    # The item key is the file name and the value is an array containing its
+    # includes. Note that only direct includes are added. Indirect includes
+    # are handled below.
+    sources = {
+        'main.c': [
+            'main.h',
+            'defines.h',
+            'hashmap.h',
+            'include_file.h',
+            'listfile.h',
+            'mersenne_twister.h',
+            'parse.h',
+            'pass_1.h',
+            'pass_2.h',
+            'pass_3.h',
+            'pass_4.h',
+            'printf.h',
+        ],
+        'crc32.c': [
+            'crc32.h'
+        ],
+        'hashmap.c': [
+            'hashmap.h',
+            'crc32.h',
+        ],
+        'include_file.c': [
+            'include_file.h',
+            'crc32.h',
+            'defines.h',
+            'parse.h',
+            'pass_1.h',
+            'printf.h',
+        ],
+        'listfile.c': [
+            'listfile.h',
+            'defines.h',
+            'include_file.h',
+        ],
+        'mersenne_twister.c': [
+            'mersenne_twister.h'
+        ],
+        'parse.c': [
+            'parse.h',
+            'defines.h',
+            'pass_1.h',
+            'stack.h',
+            'include_file.h',
+            'printf.h',
+        ],
+        'pass_1.c': [
+            'pass_1.h',
+            'defines.h',
+            'main.h',
+            'include_file.h',
+            'parse.h',
+            'pass_2.h',
+            'pass_3.h',
+            'stack.h',
+            'hashmap.h',
+            'printf.h',
+            'mersenne_twister.h',
+            'decode_' + cpu['name'] + '.c',
+        ],
+        'pass_2.c': [
+            'pass_2.h',
+            'defines.h',
+            'pass_1.h',
+            'pass_4.h',
+            'hashmap.h',
+            'printf.h',
+        ],
+        'pass_3.c': [
+            'pass_3.h',
+            'defines.h',
+            'include_file.h',
+            'printf.h',
+        ],
+        'pass_4.c': [
+            'defines.h',
+            'include_file.h',
+            'listfile.h',
+            'pass_3.h',
+            'pass_4.h',
+            'parse.h',
+            'stack.h',
+            'printf.h',
+        ],
+        'printf.c': [
+            'printf.h'
+        ],
+        'stack.c': [
+            'stack.h',
+            'defines.h',
+            'hashmap.h',
+            'parse.h',
+            'pass_1.h',
+            'include_file.h',
+            'printf.h',
+        ],
+        'opcodes_' + cpu['name'] + '_tables.c': [],
+        'opcodes_' + cpu['name'] + '.c': [],
+    }
+
+    # It's possible that an header such as defines.h includes other headers.
+    # So we use this dictionary to automatically add those as well.
+    headers = {
+        'defines.h': [
+            'hashmap.h',
+            'shared.h',
+        ]
+    }
+
+
+    rules = []
+
+    # Now build the rules list by iterating the source files
+    # and adding their direct and indirect dependencies. 
+    for source, deps in sources.items():
+        obj = source[:-2] + '.o'
+        rule = obj + ': ' + source + ' '
+        rule_deps = []
+        for dep in deps:
+            rule_deps.append(dep)
+            if dep in headers:
+                rule_deps += headers[dep]
+
+        rule += ' '.join(rule_deps) + '\r\n\t$(CC) $(CFLAGS) ' + source
+
+        rules.append(rule)
+    
+    rules.sort()
+    
+    # After all rules for this CPU are created, we prepare the variables to
+    # substitute in the templates, apply them and save the files
+    substitutions = {
+        'CPU': cpu['name'],
+        'CPU_DEFINE': cpu['define'],
+        'OFILES': ' '.join([s[:-2] + '.o' for s in sources]),
+        'RULES': '\r\n\r\n'.join(rules),
+    }
+
+    msdos_out = msdos_template.safe_substitute(substitutions)
+    
+    if not os.path.exists(output_folder):
+        os.mkdir(output_folder)
+
+    f = open(output_folder + '/makefile.msdos.' + cpu['name'], "w")
+    f.write(msdos_out)
+    f.close()

--- a/historical/makefile_generator/makefile.amiga.template
+++ b/historical/makefile_generator/makefile.amiga.template
@@ -1,0 +1,23 @@
+CC=gcc
+LD=gcc
+
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -D@CPU_DEFINE
+LDFLAGS = -lm
+
+OFILES = @OFILES
+
+
+all: $(OFILES) makefile
+	$(LD) $(OFILES) -o wla-@CPU $(LDFLAGS)
+	strip wla-@CPU
+
+
+@RULES
+
+
+clean:
+	delete $(OFILES) >nil:
+
+install:
+	make
+	move wla-@CPU TO binaries

--- a/historical/makefile_generator/makefile.msdos.template
+++ b/historical/makefile_generator/makefile.msdos.template
@@ -1,0 +1,18 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
+
+CC = gcc
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -D@CPU_DEFINE -DNDEBUG=1
+LD = gcc
+LDFLAGS = -lm
+
+OFILES = @OFILES
+
+all: $(OFILES)
+	$(LD) $(LDFLAGS) $(OFILES) -o wla-@CPU.exe
+
+@RULES
+
+clean:
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-@CPU.exe

--- a/historical/makefile_generator/makefile.msdos.template
+++ b/historical/makefile_generator/makefile.msdos.template
@@ -1,6 +1,3 @@
-###################################################
-# WARNING: This file was automatically generated. # 
-###################################################
 
 CC = gcc
 CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -D@CPU_DEFINE -DNDEBUG=1

--- a/historical/makefile_generator/makefile.msdos.template
+++ b/historical/makefile_generator/makefile.msdos.template
@@ -6,11 +6,11 @@ LDFLAGS = -lm
 OFILES = @OFILES
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-@CPU.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-@CPU.exe
 
 
 @RULES
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-@CPU.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-@CPU.exe

--- a/historical/makefile_generator/makefile.msdos.template
+++ b/historical/makefile_generator/makefile.msdos.template
@@ -1,4 +1,3 @@
-
 CC = gcc
 CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -D@CPU_DEFINE -DNDEBUG=1
 LD = gcc
@@ -9,7 +8,9 @@ OFILES = @OFILES
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-@CPU.exe
 
+
 @RULES
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-@CPU.exe

--- a/historical/makefile_generator/makefile.smake.template
+++ b/historical/makefile_generator/makefile.smake.template
@@ -1,0 +1,24 @@
+
+CMATH = MATH=STANDARD
+MATH = m		# math link library designation
+
+CC = sc
+CFLAGS = define AMIGA=1 define @CPU_DEFINE=1 define NDEBUG=1
+LINKER = slink
+LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
+LFLAGS = STRIPDEBUG NOICONS
+
+OFILES = @OFILES
+
+
+all: main
+
+main: $(OFILES) smakefile SCOPTIONS
+	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
+
+
+@RULES
+
+
+clean:
+	delete \#?.o \#?.gb \#?.lnk \#?.info wla

--- a/historical/makefiles/makefile.amiga.6502
+++ b/historical/makefiles/makefile.amiga.6502
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DMCS6502
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DMCS6502
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6502_tables.c opcodes_6502.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6502_tables.o opcodes_6502.o
+OFILES = opcodes_6502.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_6502_tables.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-6502 $(LDFLAGS)
 	strip wla-6502
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_6502_tables.o: opcodes_6502_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6502_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_6502.o: opcodes_6502.c
-	$(CC) $(WLAFLAGS) opcodes_6502.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_6502.o: opcodes_6502.c 
+	$(CC) $(CFLAGS) opcodes_6502.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_6502_tables.o: opcodes_6502_tables.c 
+	$(CC) $(CFLAGS) opcodes_6502_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6502.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.6510
+++ b/historical/makefiles/makefile.amiga.6510
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DMCS6510
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DMCS6510
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6510_tables.c opcodes_6510.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6510_tables.o opcodes_6510.o
+OFILES = opcodes_6510.o mersenne_twister.o crc32.o hashmap.o opcodes_6510_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-6510 $(LDFLAGS)
 	strip wla-6510
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_6510_tables.o: opcodes_6510_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6510_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_6510.o: opcodes_6510.c
-	$(CC) $(WLAFLAGS) opcodes_6510.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_6510.o: opcodes_6510.c 
+	$(CC) $(CFLAGS) opcodes_6510.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_6510_tables.o: opcodes_6510_tables.c 
+	$(CC) $(CFLAGS) opcodes_6510_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6510.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.65816
+++ b/historical/makefiles/makefile.amiga.65816
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DW65816
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DW65816
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65816_tables.c opcodes_65816.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65816_tables.o opcodes_65816.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_65816.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_65816_tables.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-65816 $(LDFLAGS)
 	strip wla-65816
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_65816_tables.o: opcodes_65816_tables.c
-	$(CC) $(WLAFLAGS) opcodes_65816_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_65816.o: opcodes_65816.c
-	$(CC) $(WLAFLAGS) opcodes_65816.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_65816.o: opcodes_65816.c 
+	$(CC) $(CFLAGS) opcodes_65816.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_65816_tables.o: opcodes_65816_tables.c 
+	$(CC) $(CFLAGS) opcodes_65816_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65816.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.65c02
+++ b/historical/makefiles/makefile.amiga.65c02
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DWDC65C02
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DWDC65C02
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65c02_tables.c opcodes_65c02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65c02_tables.o opcodes_65c02.o
+OFILES = opcodes_65c02.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o opcodes_65c02_tables.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-65c02 $(LDFLAGS)
 	strip wla-65c02
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_65c02_tables.o: opcodes_65c02_tables.c
-	$(CC) $(WLAFLAGS) opcodes_65c02_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_65c02.o: opcodes_65c02.c
-	$(CC) $(WLAFLAGS) opcodes_65c02.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_65c02.o: opcodes_65c02.c 
+	$(CC) $(CFLAGS) opcodes_65c02.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_65c02_tables.o: opcodes_65c02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65c02_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65c02.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
-	
-$(OFILES): $(HFILES)
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.65ce02
+++ b/historical/makefiles/makefile.amiga.65ce02
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DCSG65CE02
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DCSG65CE02
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65ce02_tables.c opcodes_65ce02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65ce02_tables.o opcodes_65ce02.o
+OFILES = mersenne_twister.o opcodes_65ce02_tables.o crc32.o hashmap.o stack.o parse.o opcodes_65ce02.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-65ce02 $(LDFLAGS)
 	strip wla-65ce02
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_65ce02_tables.o: opcodes_65ce02_tables.c
-	$(CC) $(WLAFLAGS) opcodes_65ce02_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_65ce02.o: opcodes_65ce02.c
-	$(CC) $(WLAFLAGS) opcodes_65ce02.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_65ce02.o: opcodes_65ce02.c 
+	$(CC) $(CFLAGS) opcodes_65ce02.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_65ce02_tables.o: opcodes_65ce02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65ce02.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
-	
-$(OFILES): $(HFILES)
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.6800
+++ b/historical/makefiles/makefile.amiga.6800
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DMC6800
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DMC6800
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6800_tables.c opcodes_6800.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6800_tables.o opcodes_6800.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_6800_tables.o listfile.o pass_3.o opcodes_6800.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-6800 $(LDFLAGS)
 	strip wla-6800
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_6800_tables.o: opcodes_6800_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6800_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_6800.o: opcodes_6800.c
-	$(CC) $(WLAFLAGS) opcodes_6800.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_6800.o: opcodes_6800.c 
+	$(CC) $(CFLAGS) opcodes_6800.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_6800_tables.o: opcodes_6800_tables.c 
+	$(CC) $(CFLAGS) opcodes_6800_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6800.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.6801
+++ b/historical/makefiles/makefile.amiga.6801
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DMC6801
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DMC6801
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6801_tables.c opcodes_6801.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6801_tables.o opcodes_6801.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o opcodes_6801_tables.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_6801.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-6801 $(LDFLAGS)
 	strip wla-6801
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_6801_tables.o: opcodes_6801_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6801_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_6801.o: opcodes_6801.c
-	$(CC) $(WLAFLAGS) opcodes_6801.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_6801.o: opcodes_6801.c 
+	$(CC) $(CFLAGS) opcodes_6801.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_6801_tables.o: opcodes_6801_tables.c 
+	$(CC) $(CFLAGS) opcodes_6801_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6801.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.6809
+++ b/historical/makefiles/makefile.amiga.6809
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DMC6809
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DMC6809
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6809_tables.c opcodes_6809.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6809_tables.o opcodes_6809.o
+OFILES = opcodes_6809.o mersenne_twister.o crc32.o hashmap.o opcodes_6809_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-6809 $(LDFLAGS)
 	strip wla-6809
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_6809_tables.o: opcodes_6809_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6809_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_6809.o: opcodes_6809.c
-	$(CC) $(WLAFLAGS) opcodes_6809.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_6809.o: opcodes_6809.c 
+	$(CC) $(CFLAGS) opcodes_6809.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_6809_tables.o: opcodes_6809_tables.c 
+	$(CC) $(CFLAGS) opcodes_6809_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6809.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.8008
+++ b/historical/makefiles/makefile.amiga.8008
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DI8008
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DI8008
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8008_tables.c opcodes_8008.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8008_tables.o opcodes_8008.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_8008.o listfile.o pass_3.o opcodes_8008_tables.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-8008 $(LDFLAGS)
 	strip wla-8008
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_8008_tables.o: opcodes_8008_tables.c
-	$(CC) $(WLAFLAGS) opcodes_8008_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_8008.o: opcodes_8008.c
-	$(CC) $(WLAFLAGS) opcodes_8008.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_8008.o: opcodes_8008.c 
+	$(CC) $(CFLAGS) opcodes_8008.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_8008_tables.o: opcodes_8008_tables.c 
+	$(CC) $(CFLAGS) opcodes_8008_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8008.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.8080
+++ b/historical/makefiles/makefile.amiga.8080
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DI8080
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DI8080
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8080_tables.c opcodes_8080.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8080_tables.o opcodes_8080.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o opcodes_8080_tables.o pass_2.o listfile.o pass_3.o include_file.o opcodes_8080.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-8080 $(LDFLAGS)
 	strip wla-8080
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_8080_tables.o: opcodes_8080_tables.c
-	$(CC) $(WLAFLAGS) opcodes_8080_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_8080.o: opcodes_8080.c
-	$(CC) $(WLAFLAGS) opcodes_8080.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_8080.o: opcodes_8080.c 
+	$(CC) $(CFLAGS) opcodes_8080.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_8080_tables.o: opcodes_8080_tables.c 
+	$(CC) $(CFLAGS) opcodes_8080_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8080.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.gb
+++ b/historical/makefiles/makefile.amiga.gb
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DGB
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DGB
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_gb_tables.c opcodes_gb.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_gb_tables.o opcodes_gb.o
+OFILES = opcodes_gb_tables.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_gb.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-gb $(LDFLAGS)
 	strip wla-gb
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_gb_tables.o: opcodes_gb_tables.c
-	$(CC) $(WLAFLAGS) opcodes_gb_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_gb.o: opcodes_gb.c
-	$(CC) $(WLAFLAGS) opcodes_gb.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_gb.o: opcodes_gb.c 
+	$(CC) $(CFLAGS) opcodes_gb.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_gb_tables.o: opcodes_gb_tables.c 
+	$(CC) $(CFLAGS) opcodes_gb_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_gb.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.huc6280
+++ b/historical/makefiles/makefile.amiga.huc6280
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DHUC6280
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DHUC6280
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_huc6280_tables.c opcodes_huc6280.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_huc6280_tables.o opcodes_huc6280.o
+OFILES = mersenne_twister.o crc32.o opcodes_huc6280_tables.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_huc6280.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-huc6280 $(LDFLAGS)
 	strip wla-huc6280
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_huc6280_tables.o: opcodes_huc6280_tables.c
-	$(CC) $(WLAFLAGS) opcodes_huc6280_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_huc6280.o: opcodes_huc6280.c
-	$(CC) $(WLAFLAGS) opcodes_huc6280.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_huc6280.o: opcodes_huc6280.c 
+	$(CC) $(CFLAGS) opcodes_huc6280.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_huc6280_tables.o: opcodes_huc6280_tables.c 
+	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_huc6280.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:
@@ -68,4 +67,4 @@ clean:
 
 install:
 	make
-	move wla-huc6280 to binaries/
+	move wla-huc6280 TO binaries

--- a/historical/makefiles/makefile.amiga.spc700
+++ b/historical/makefiles/makefile.amiga.spc700
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DSPC700
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DSPC700
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_spc700_tables.c opcodes_spc700.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_spc700_tables.o opcodes_spc700.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_spc700.o opcodes_spc700_tables.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-spc700 $(LDFLAGS)
 	strip wla-spc700
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_spc700_tables.o: opcodes_spc700_tables.c
-	$(CC) $(WLAFLAGS) opcodes_spc700_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_spc700.o: opcodes_spc700.c
-	$(CC) $(WLAFLAGS) opcodes_spc700.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_spc700.o: opcodes_spc700.c 
+	$(CC) $(CFLAGS) opcodes_spc700.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_spc700_tables.o: opcodes_spc700_tables.c 
+	$(CC) $(CFLAGS) opcodes_spc700_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_spc700.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.amiga.z80
+++ b/historical/makefiles/makefile.amiga.z80
@@ -1,66 +1,65 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
 
 CC=gcc
 LD=gcc
 
-CFLAGS?= -c -O3 -ansi -pedantic -Wall
+CFLAGS= -c -O3 -ansi -pedantic -Wall -DUNIX -DZ80
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS) -DUNIX -DZ80
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_z80_tables.c opcodes_z80.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_z80_tables.o opcodes_z80.o
+OFILES = opcodes_z80_tables.o opcodes_z80.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: $(OFILES) makefile
 	$(LD) $(OFILES) -o wla-z80 $(LDFLAGS)
 	strip wla-z80
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(WLAFLAGS) main.c
 
-printf.o: printf.c printf.h makefile
-	$(CC) $(WLAFLAGS) printf.c
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
 
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(WLAFLAGS) parse.c
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
 
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(WLAFLAGS) include_file.c
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
 
-opcodes_z80_tables.o: opcodes_z80_tables.c
-	$(CC) $(WLAFLAGS) opcodes_z80_tables.c
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
 
-opcodes_z80.o: opcodes_z80.c
-	$(CC) $(WLAFLAGS) opcodes_z80.c
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
 
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(WLAFLAGS) pass_1.c
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
 
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(WLAFLAGS) pass_2.c
+opcodes_z80.o: opcodes_z80.c 
+	$(CC) $(CFLAGS) opcodes_z80.c
 
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(WLAFLAGS) pass_3.c
+opcodes_z80_tables.o: opcodes_z80_tables.c 
+	$(CC) $(CFLAGS) opcodes_z80_tables.c
 
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(WLAFLAGS) pass_4.c
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
 
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(WLAFLAGS) stack.c
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_z80.c
+	$(CC) $(CFLAGS) pass_1.c
 
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(WLAFLAGS) listfile.c
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
 
-crc32.o: crc32.c defines.h crc32.h makefile
-	$(CC) $(WLAFLAGS) crc32.c
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
-	$(CC) $(WLAFLAGS) hashmap.c
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
-	$(CC) $(WLAFLAGS) mersenne_twister.c
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
 
-$(OFILES): $(HFILES)
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 
 clean:

--- a/historical/makefiles/makefile.msdos.6502
+++ b/historical/makefiles/makefile.msdos.6502
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_6502.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o opc
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6502.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6502.exe

--- a/historical/makefiles/makefile.msdos.6502
+++ b/historical/makefiles/makefile.msdos.6502
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_6502.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_6502_tables.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6502.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-6502.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6502.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-6502.exe

--- a/historical/makefiles/makefile.msdos.6502
+++ b/historical/makefiles/makefile.msdos.6502
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6502
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6502 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6502_tables.c opcodes_6502.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6502_tables.o opcodes_6502.o
+OFILES = opcodes_6502.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_6502_tables.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6502.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6502_tables.o: opcodes_6502_tables.c
-	$(CC) $(CFLAGS) opcodes_6502_tables.c
-
-opcodes_6502.o: opcodes_6502.c
-	$(CC) $(CFLAGS) opcodes_6502.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_6502.o: opcodes_6502.c 
+	$(CC) $(CFLAGS) opcodes_6502.c
 
+opcodes_6502_tables.o: opcodes_6502_tables.c 
+	$(CC) $(CFLAGS) opcodes_6502_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6502.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-6502.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6502.exe

--- a/historical/makefiles/makefile.msdos.6510
+++ b/historical/makefiles/makefile.msdos.6510
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_6510.o mersenne_twister.o crc32.o hashmap.o opcodes_6510_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6510.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-6510.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6510.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-6510.exe

--- a/historical/makefiles/makefile.msdos.6510
+++ b/historical/makefiles/makefile.msdos.6510
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6510
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMCS6510 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6510_tables.c opcodes_6510.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6510_tables.o opcodes_6510.o
+OFILES = opcodes_6510.o mersenne_twister.o crc32.o hashmap.o opcodes_6510_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6510.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6510_tables.o: opcodes_6510_tables.c
-	$(CC) $(CFLAGS) opcodes_6510_tables.c
-
-opcodes_6510.o: opcodes_6510.c
-	$(CC) $(CFLAGS) opcodes_6510.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_6510.o: opcodes_6510.c 
+	$(CC) $(CFLAGS) opcodes_6510.c
 
+opcodes_6510_tables.o: opcodes_6510_tables.c 
+	$(CC) $(CFLAGS) opcodes_6510_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6510.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-6510.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6510.exe

--- a/historical/makefiles/makefile.msdos.6510
+++ b/historical/makefiles/makefile.msdos.6510
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_6510.o mersenne_twister.o crc32.o hashmap.o opcodes_6510_tables
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6510.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6510.exe

--- a/historical/makefiles/makefile.msdos.65816
+++ b/historical/makefiles/makefile.msdos.65816
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_65816.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_65816_tables.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65816.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-65816.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65816.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-65816.exe

--- a/historical/makefiles/makefile.msdos.65816
+++ b/historical/makefiles/makefile.msdos.65816
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_65816.o ma
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65816.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65816.exe

--- a/historical/makefiles/makefile.msdos.65816
+++ b/historical/makefiles/makefile.msdos.65816
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DW65816
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DW65816 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65816_tables.c opcodes_65816.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65816_tables.o opcodes_65816.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_65816.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_65816_tables.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65816.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65816_tables.o: opcodes_65816_tables.c
-	$(CC) $(CFLAGS) opcodes_65816_tables.c
-
-opcodes_65816.o: opcodes_65816.c
-	$(CC) $(CFLAGS) opcodes_65816.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_65816.o: opcodes_65816.c 
+	$(CC) $(CFLAGS) opcodes_65816.c
 
+opcodes_65816_tables.o: opcodes_65816_tables.c 
+	$(CC) $(CFLAGS) opcodes_65816_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65816.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-65816.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65816.exe

--- a/historical/makefiles/makefile.msdos.65c02
+++ b/historical/makefiles/makefile.msdos.65c02
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_65c02.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o opcodes_65c02_tables.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65c02.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-65c02.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65c02.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-65c02.exe

--- a/historical/makefiles/makefile.msdos.65c02
+++ b/historical/makefiles/makefile.msdos.65c02
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DWDC65C02
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DWDC65C02 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65c02_tables.c opcodes_65c02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65c02_tables.o opcodes_65c02.o
+OFILES = opcodes_65c02.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o opcodes_65c02_tables.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65c02.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65c02_tables.o: opcodes_65c02_tables.c
-	$(CC) $(CFLAGS) opcodes_65c02_tables.c
-
-opcodes_65c02.o: opcodes_65c02.c
-	$(CC) $(CFLAGS) opcodes_65c02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_65c02.o: opcodes_65c02.c 
+	$(CC) $(CFLAGS) opcodes_65c02.c
 
+opcodes_65c02_tables.o: opcodes_65c02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65c02_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65c02.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-65c02.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65c02.exe

--- a/historical/makefiles/makefile.msdos.65c02
+++ b/historical/makefiles/makefile.msdos.65c02
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_65c02.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o ma
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65c02.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65c02.exe

--- a/historical/makefiles/makefile.msdos.65ce02
+++ b/historical/makefiles/makefile.msdos.65ce02
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o opcodes_65ce02_tables.o crc32.o hashmap.o stack.o parse.o opcodes_65ce02.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-65ce02.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-65ce02.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65ce02.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-65ce02.exe

--- a/historical/makefiles/makefile.msdos.65ce02
+++ b/historical/makefiles/makefile.msdos.65ce02
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o opcodes_65ce02_tables.o crc32.o hashmap.o stack.o pa
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65ce02.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65ce02.exe

--- a/historical/makefiles/makefile.msdos.65ce02
+++ b/historical/makefiles/makefile.msdos.65ce02
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DCSG65CE02
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DCSG65CE02 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65ce02_tables.c opcodes_65ce02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65ce02_tables.o opcodes_65ce02.o
+OFILES = mersenne_twister.o opcodes_65ce02_tables.o crc32.o hashmap.o stack.o parse.o opcodes_65ce02.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-65ce02.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65ce02_tables.o: opcodes_65ce02_tables.c
-	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
-
-opcodes_65ce02.o: opcodes_65ce02.c
-	$(CC) $(CFLAGS) opcodes_65ce02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_65ce02.o: opcodes_65ce02.c 
+	$(CC) $(CFLAGS) opcodes_65ce02.c
 
+opcodes_65ce02_tables.o: opcodes_65ce02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65ce02.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-65ce02.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-65ce02.exe

--- a/historical/makefiles/makefile.msdos.6800
+++ b/historical/makefiles/makefile.msdos.6800
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_6800_tables.o listfile.o pass_3.o opcodes_6800.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6800.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-6800.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6800.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-6800.exe

--- a/historical/makefiles/makefile.msdos.6800
+++ b/historical/makefiles/makefile.msdos.6800
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6800
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6800 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6800_tables.c opcodes_6800.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6800_tables.o opcodes_6800.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_6800_tables.o listfile.o pass_3.o opcodes_6800.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6800.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6800_tables.o: opcodes_6800_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6800_tables.c
-
-opcodes_6800.o: opcodes_6800.c
-	$(CC) $(WLAFLAGS) opcodes_6800.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_6800.o: opcodes_6800.c 
+	$(CC) $(CFLAGS) opcodes_6800.c
 
+opcodes_6800_tables.o: opcodes_6800_tables.c 
+	$(CC) $(CFLAGS) opcodes_6800_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6800.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-6800.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6800.exe

--- a/historical/makefiles/makefile.msdos.6800
+++ b/historical/makefiles/makefile.msdos.6800
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pa
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6800.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6800.exe

--- a/historical/makefiles/makefile.msdos.6801
+++ b/historical/makefiles/makefile.msdos.6801
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o opcodes_6801_tables.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_6801.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6801.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-6801.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6801.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-6801.exe

--- a/historical/makefiles/makefile.msdos.6801
+++ b/historical/makefiles/makefile.msdos.6801
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o opcodes_680
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6801.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6801.exe

--- a/historical/makefiles/makefile.msdos.6801
+++ b/historical/makefiles/makefile.msdos.6801
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6801
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6801 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6801_tables.c opcodes_6801.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6801_tables.o opcodes_6801.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o opcodes_6801_tables.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_6801.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6801.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6801_tables.o: opcodes_6801_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6801_tables.c
-
-opcodes_6801.o: opcodes_6801.c
-	$(CC) $(WLAFLAGS) opcodes_6801.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_6801.o: opcodes_6801.c 
+	$(CC) $(CFLAGS) opcodes_6801.c
 
+opcodes_6801_tables.o: opcodes_6801_tables.c 
+	$(CC) $(CFLAGS) opcodes_6801_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6801.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-6801.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6801.exe

--- a/historical/makefiles/makefile.msdos.6809
+++ b/historical/makefiles/makefile.msdos.6809
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_6809.o mersenne_twister.o crc32.o hashmap.o opcodes_6809_tables
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6809.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6809.exe

--- a/historical/makefiles/makefile.msdos.6809
+++ b/historical/makefiles/makefile.msdos.6809
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_6809.o mersenne_twister.o crc32.o hashmap.o opcodes_6809_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-6809.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-6809.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6809.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-6809.exe

--- a/historical/makefiles/makefile.msdos.6809
+++ b/historical/makefiles/makefile.msdos.6809
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6809
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DMC6809 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6809_tables.c opcodes_6809.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6809_tables.o opcodes_6809.o
+OFILES = opcodes_6809.o mersenne_twister.o crc32.o hashmap.o opcodes_6809_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-6809.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6809_tables.o: opcodes_6809_tables.c
-	$(CC) $(WLAFLAGS) opcodes_6809_tables.c
-
-opcodes_6809.o: opcodes_6809.c
-	$(CC) $(WLAFLAGS) opcodes_6809.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_6809.o: opcodes_6809.c 
+	$(CC) $(CFLAGS) opcodes_6809.c
 
+opcodes_6809_tables.o: opcodes_6809_tables.c 
+	$(CC) $(CFLAGS) opcodes_6809_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6809.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-6809.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-6809.exe

--- a/historical/makefiles/makefile.msdos.8008
+++ b/historical/makefiles/makefile.msdos.8008
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_8008.o listfile.o pass_3.o opcodes_8008_tables.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-8008.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-8008.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8008.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-8008.exe

--- a/historical/makefiles/makefile.msdos.8008
+++ b/historical/makefiles/makefile.msdos.8008
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pa
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-8008.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8008.exe

--- a/historical/makefiles/makefile.msdos.8008
+++ b/historical/makefiles/makefile.msdos.8008
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8008
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8008 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8008_tables.c opcodes_8008.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8008_tables.o opcodes_8008.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_8008.o listfile.o pass_3.o opcodes_8008_tables.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-8008.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8008_tables.o: opcodes_8008_tables.c
-	$(CC) $(CFLAGS) opcodes_8008_tables.c
-
-opcodes_8008.o: opcodes_8008.c
-	$(CC) $(CFLAGS) opcodes_8008.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_8008.o: opcodes_8008.c 
+	$(CC) $(CFLAGS) opcodes_8008.c
 
+opcodes_8008_tables.o: opcodes_8008_tables.c 
+	$(CC) $(CFLAGS) opcodes_8008_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8008.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-8008.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8008.exe

--- a/historical/makefiles/makefile.msdos.8080
+++ b/historical/makefiles/makefile.msdos.8080
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pa
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-8080.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8080.exe

--- a/historical/makefiles/makefile.msdos.8080
+++ b/historical/makefiles/makefile.msdos.8080
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8080
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DI8080 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8080_tables.c opcodes_8080.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8080_tables.o opcodes_8080.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o opcodes_8080_tables.o pass_2.o listfile.o pass_3.o include_file.o opcodes_8080.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-8080.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8080_tables.o: opcodes_8080_tables.c
-	$(CC) $(CFLAGS) opcodes_8080_tables.c
-
-opcodes_8080.o: opcodes_8080.c
-	$(CC) $(CFLAGS) opcodes_8080.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_8080.o: opcodes_8080.c 
+	$(CC) $(CFLAGS) opcodes_8080.c
 
+opcodes_8080_tables.o: opcodes_8080_tables.c 
+	$(CC) $(CFLAGS) opcodes_8080_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8080.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-8080.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8080.exe

--- a/historical/makefiles/makefile.msdos.8080
+++ b/historical/makefiles/makefile.msdos.8080
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o opcodes_8080_tables.o pass_2.o listfile.o pass_3.o include_file.o opcodes_8080.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-8080.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-8080.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-8080.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-8080.exe

--- a/historical/makefiles/makefile.msdos.gb
+++ b/historical/makefiles/makefile.msdos.gb
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DGB
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DGB -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_gb_tables.c opcodes_gb.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_gb_tables.o opcodes_gb.o
+OFILES = opcodes_gb_tables.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_gb.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-gb.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_gb_tables.o: opcodes_gb_tables.c
-	$(CC) $(CFLAGS) opcodes_gb_tables.c
-
-opcodes_gb.o: opcodes_gb.c
-	$(CC) $(CFLAGS) opcodes_gb.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_gb.o: opcodes_gb.c 
+	$(CC) $(CFLAGS) opcodes_gb.c
 
+opcodes_gb_tables.o: opcodes_gb_tables.c 
+	$(CC) $(CFLAGS) opcodes_gb_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_gb.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-gb.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-gb.exe

--- a/historical/makefiles/makefile.msdos.gb
+++ b/historical/makefiles/makefile.msdos.gb
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_gb_tables.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_gb.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-gb.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-gb.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-gb.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-gb.exe

--- a/historical/makefiles/makefile.msdos.gb
+++ b/historical/makefiles/makefile.msdos.gb
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_gb_tables.o mersenne_twister.o crc32.o hashmap.o stack.o parse.
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-gb.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-gb.exe

--- a/historical/makefiles/makefile.msdos.huc6280
+++ b/historical/makefiles/makefile.msdos.huc6280
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DHUC6280
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DHUC6280 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_huc6280_tables.c opcodes_huc6280.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_huc6280_tables.o opcodes_huc6280.o
+OFILES = mersenne_twister.o crc32.o opcodes_huc6280_tables.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_huc6280.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-huc6280.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_huc6280_tables.o: opcodes_huc6280_tables.c
-	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
-
-opcodes_huc6280.o: opcodes_huc6280.c
-	$(CC) $(CFLAGS) opcodes_huc6280.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_huc6280.o: opcodes_huc6280.c 
+	$(CC) $(CFLAGS) opcodes_huc6280.c
 
+opcodes_huc6280_tables.o: opcodes_huc6280_tables.c 
+	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_huc6280.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-huc6280.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-huc6280.exe

--- a/historical/makefiles/makefile.msdos.huc6280
+++ b/historical/makefiles/makefile.msdos.huc6280
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o opcodes_huc6280_tables.o hashmap.o stack.o p
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-huc6280.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-huc6280.exe

--- a/historical/makefiles/makefile.msdos.huc6280
+++ b/historical/makefiles/makefile.msdos.huc6280
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o opcodes_huc6280_tables.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_huc6280.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-huc6280.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-huc6280.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-huc6280.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-huc6280.exe

--- a/historical/makefiles/makefile.msdos.spc700
+++ b/historical/makefiles/makefile.msdos.spc700
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pa
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-spc700.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-spc700.exe

--- a/historical/makefiles/makefile.msdos.spc700
+++ b/historical/makefiles/makefile.msdos.spc700
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_spc700.o opcodes_spc700_tables.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-spc700.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-spc700.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-spc700.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-spc700.exe

--- a/historical/makefiles/makefile.msdos.spc700
+++ b/historical/makefiles/makefile.msdos.spc700
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DSPC700
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DSPC700 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_spc700_tables.c opcodes_spc700.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_spc700_tables.o opcodes_spc700.o
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_spc700.o opcodes_spc700_tables.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-spc700.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_spc700_tables.o: opcodes_spc700_tables.c
-	$(CC) $(CFLAGS) opcodes_spc700_tables.c
-
-opcodes_spc700.o: opcodes_spc700.c
-	$(CC) $(CFLAGS) opcodes_spc700.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_spc700.o: opcodes_spc700.c 
+	$(CC) $(CFLAGS) opcodes_spc700.c
 
+opcodes_spc700_tables.o: opcodes_spc700_tables.c 
+	$(CC) $(CFLAGS) opcodes_spc700_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_spc700.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-spc700.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-spc700.exe

--- a/historical/makefiles/makefile.msdos.z80
+++ b/historical/makefiles/makefile.msdos.z80
@@ -10,7 +10,7 @@ LDFLAGS = -lm
 OFILES = opcodes_z80_tables.o opcodes_z80.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 all: $(OFILES)
-	$(LD) $(LDFLAGS) $(OFILES) -o wla-z80.exe
+	$(LD) $(LDFLAGS) $(OFILES) -o w-z80.exe
 
 
 crc32.o: crc32.c crc32.h
@@ -60,4 +60,4 @@ stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h
 
 
 clean:
-	DEL /F /Q *.o; DEL /F /Q *.d; del wla-z80.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del w-z80.exe

--- a/historical/makefiles/makefile.msdos.z80
+++ b/historical/makefiles/makefile.msdos.z80
@@ -1,5 +1,5 @@
 ###################################################
-# WARNING: This file was automatically generated. # 
+# WARNING: This file was automatically generated. #
 ###################################################
 
 CC = gcc
@@ -11,6 +11,7 @@ OFILES = opcodes_z80_tables.o opcodes_z80.o mersenne_twister.o crc32.o hashmap.o
 
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-z80.exe
+
 
 crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
@@ -56,6 +57,7 @@ printf.o: printf.c printf.h
 
 stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
+
 
 clean:
 	DEL /F /Q *.o; DEL /F /Q *.d; del wla-z80.exe

--- a/historical/makefiles/makefile.msdos.z80
+++ b/historical/makefiles/makefile.msdos.z80
@@ -1,65 +1,61 @@
+###################################################
+# WARNING: This file was automatically generated. # 
+###################################################
 
 CC = gcc
-CFLAGS = -m486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DZ80
+CFLAGS = -mtune=i486 -c -O3 -ansi -pedantic -Wall -DMSDOS -DZ80 -DNDEBUG=1
 LD = gcc
 LDFLAGS = -lm
-WLAFLAGS = $(CFLAGS)
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_z80_tables.c opcodes_z80.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_z80_tables.o opcodes_z80.o
+OFILES = opcodes_z80_tables.o opcodes_z80.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
-
-all: $(OFILES) makefile
+all: $(OFILES)
 	$(LD) $(LDFLAGS) $(OFILES) -o wla-z80.exe
 
-main.o: main.c defines.h main.h makefile
-	$(CC) $(CFLAGS) main.c
-
-printf.o: printf.c printf.h makefile
-	$(CC) $(CFLAGS) printf.c
-
-parse.o: parse.c defines.h parse.h makefile
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h makefile
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_z80_tables.o: opcodes_z80_tables.c
-	$(CC) $(CFLAGS) opcodes_z80_tables.c
-
-opcodes_z80.o: opcodes_z80.c
-	$(CC) $(CFLAGS) opcodes_z80.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h makefile
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h makefile
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h makefile
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h makefile
-	$(CC) $(CFLAGS) pass_4.c
-
-stack.o: stack.c defines.h stack.h makefile
-	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h makefile
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h makefile
+crc32.o: crc32.c crc32.h
 	$(CC) $(CFLAGS) crc32.c
 
-hashmap.o: hashmap.c defines.h hashmap.h makefile
+hashmap.o: hashmap.c hashmap.h crc32.h
 	$(CC) $(CFLAGS) hashmap.c
 
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h makefile
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
+	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
 	$(CC) $(CFLAGS) mersenne_twister.c
 
-$(OFILES): $(HFILES)
+opcodes_z80.o: opcodes_z80.c 
+	$(CC) $(CFLAGS) opcodes_z80.c
 
+opcodes_z80_tables.o: opcodes_z80_tables.c 
+	$(CC) $(CFLAGS) opcodes_z80_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_z80.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
+
+printf.o: printf.c printf.h
+	$(CC) $(CFLAGS) printf.c
+
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
+	$(CC) $(CFLAGS) stack.c
 
 clean:
-	del *.o ; del *~ ; del wla-z80.exe
+	DEL /F /Q *.o; DEL /F /Q *.d; del wla-z80.exe

--- a/historical/makefiles/smake.6502
+++ b/historical/makefiles/smake.6502
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6502_tables.c opcodes_6502.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6502_tables.o opcodes_6502.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_6502.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_6502_tables.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_6502.o: opcodes_6502.c 
+	$(CC) $(CFLAGS) opcodes_6502.c
+
+opcodes_6502_tables.o: opcodes_6502_tables.c 
+	$(CC) $(CFLAGS) opcodes_6502_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6502.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6502_tables.o: opcodes_6502_tables.c
-	$(CC) $(CFLAGS) opcodes_6502_tables.c
-
-opcodes_6502.o: opcodes_6502.c
-	$(CC) $(CFLAGS) opcodes_6502.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.6510
+++ b/historical/makefiles/smake.6510
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6510_tables.c opcodes_6510.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6510_tables.o opcodes_6510.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_6510.o mersenne_twister.o crc32.o hashmap.o opcodes_6510_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_6510.o: opcodes_6510.c 
+	$(CC) $(CFLAGS) opcodes_6510.c
+
+opcodes_6510_tables.o: opcodes_6510_tables.c 
+	$(CC) $(CFLAGS) opcodes_6510_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6510.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6510_tables.o: opcodes_6510_tables.c
-	$(CC) $(CFLAGS) opcodes_6510_tables.c
-
-opcodes_6510.o: opcodes_6510.c
-	$(CC) $(CFLAGS) opcodes_6510.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.65816
+++ b/historical/makefiles/smake.65816
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65816_tables.c opcodes_65816.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65816_tables.o opcodes_65816.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o opcodes_65816.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_65816_tables.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_65816.o: opcodes_65816.c 
+	$(CC) $(CFLAGS) opcodes_65816.c
+
+opcodes_65816_tables.o: opcodes_65816_tables.c 
+	$(CC) $(CFLAGS) opcodes_65816_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65816.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65816_tables.o: opcodes_65816_tables.c
-	$(CC) $(CFLAGS) opcodes_65816_tables.c
-
-opcodes_65816.o: opcodes_65816.c
-	$(CC) $(CFLAGS) opcodes_65816.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.65c02
+++ b/historical/makefiles/smake.65c02
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65c02_tables.c opcodes_65c02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65c02_tables.o opcodes_65c02.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_65c02.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o opcodes_65c02_tables.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_65c02.o: opcodes_65c02.c 
+	$(CC) $(CFLAGS) opcodes_65c02.c
+
+opcodes_65c02_tables.o: opcodes_65c02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65c02_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65c02.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65c02_tables.o: opcodes_65c02_tables.c
-	$(CC) $(CFLAGS) opcodes_65c02_tables.c
-
-opcodes_65c02.o: opcodes_65c02.c
-	$(CC) $(CFLAGS) opcodes_65c02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.65ce02
+++ b/historical/makefiles/smake.65ce02
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_65ce02_tables.c opcodes_65ce02.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_65ce02_tables.o opcodes_65ce02.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o opcodes_65ce02_tables.o crc32.o hashmap.o stack.o parse.o opcodes_65ce02.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_65ce02.o: opcodes_65ce02.c 
+	$(CC) $(CFLAGS) opcodes_65ce02.c
+
+opcodes_65ce02_tables.o: opcodes_65ce02_tables.c 
+	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_65ce02.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_65ce02_tables.o: opcodes_65ce02_tables.c
-	$(CC) $(CFLAGS) opcodes_65ce02_tables.c
-
-opcodes_65ce02.o: opcodes_65ce02.c
-	$(CC) $(CFLAGS) opcodes_65ce02.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.6800
+++ b/historical/makefiles/smake.6800
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6800_tables.c opcodes_6800.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6800_tables.o opcodes_6800.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_6800_tables.o listfile.o pass_3.o opcodes_6800.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_6800.o: opcodes_6800.c 
+	$(CC) $(CFLAGS) opcodes_6800.c
+
+opcodes_6800_tables.o: opcodes_6800_tables.c 
+	$(CC) $(CFLAGS) opcodes_6800_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6800.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6800_tables.o: opcodes_6800_tables.c
-	$(CC) $(CFLAGS) opcodes_6800_tables.c
-
-opcodes_6800.o: opcodes_6800.c
-	$(CC) $(CFLAGS) opcodes_6800.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.6801
+++ b/historical/makefiles/smake.6801
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6801_tables.c opcodes_6801.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6801_tables.o opcodes_6801.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o opcodes_6801_tables.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_6801.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_6801.o: opcodes_6801.c 
+	$(CC) $(CFLAGS) opcodes_6801.c
+
+opcodes_6801_tables.o: opcodes_6801_tables.c 
+	$(CC) $(CFLAGS) opcodes_6801_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6801.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6801_tables.o: opcodes_6801_tables.c
-	$(CC) $(CFLAGS) opcodes_6801_tables.c
-
-opcodes_6801.o: opcodes_6801.c
-	$(CC) $(CFLAGS) opcodes_6801.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.6809
+++ b/historical/makefiles/smake.6809
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_6809_tables.c opcodes_6809.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_6809_tables.o opcodes_6809.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_6809.o mersenne_twister.o crc32.o hashmap.o opcodes_6809_tables.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_6809.o: opcodes_6809.c 
+	$(CC) $(CFLAGS) opcodes_6809.c
+
+opcodes_6809_tables.o: opcodes_6809_tables.c 
+	$(CC) $(CFLAGS) opcodes_6809_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_6809.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_6809_tables.o: opcodes_6809_tables.c
-	$(CC) $(CFLAGS) opcodes_6809_tables.c
-
-opcodes_6809.o: opcodes_6809.c
-	$(CC) $(CFLAGS) opcodes_6809.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.8008
+++ b/historical/makefiles/smake.8008
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8008_tables.c opcodes_8008.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8008_tables.o opcodes_8008.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_8008.o listfile.o pass_3.o opcodes_8008_tables.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_8008.o: opcodes_8008.c 
+	$(CC) $(CFLAGS) opcodes_8008.c
+
+opcodes_8008_tables.o: opcodes_8008_tables.c 
+	$(CC) $(CFLAGS) opcodes_8008_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8008.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8008_tables.o: opcodes_8008_tables.c
-	$(CC) $(CFLAGS) opcodes_8008_tables.c
-
-opcodes_8008.o: opcodes_8008.c
-	$(CC) $(CFLAGS) opcodes_8008.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.8080
+++ b/historical/makefiles/smake.8080
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_8080_tables.c opcodes_8080.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_8080_tables.o opcodes_8080.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o opcodes_8080_tables.o pass_2.o listfile.o pass_3.o include_file.o opcodes_8080.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_8080.o: opcodes_8080.c 
+	$(CC) $(CFLAGS) opcodes_8080.c
+
+opcodes_8080_tables.o: opcodes_8080_tables.c 
+	$(CC) $(CFLAGS) opcodes_8080_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_8080.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_8080_tables.o: opcodes_8080_tables.c
-	$(CC) $(CFLAGS) opcodes_8080_tables.c
-
-opcodes_8080.o: opcodes_8080.c
-	$(CC) $(CFLAGS) opcodes_8080.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.gb
+++ b/historical/makefiles/smake.gb
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_gb_tables.c opcodes_gb.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_gb_tables.o opcodes_gb.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_gb_tables.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_gb.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_gb.o: opcodes_gb.c 
+	$(CC) $(CFLAGS) opcodes_gb.c
+
+opcodes_gb_tables.o: opcodes_gb_tables.c 
+	$(CC) $(CFLAGS) opcodes_gb_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_gb.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_gb_tables.o: opcodes_gb_tables.c
-	$(CC) $(CFLAGS) opcodes_gb_tables.c
-
-opcodes_gb.o: opcodes_gb.c
-	$(CC) $(CFLAGS) opcodes_gb.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.huc6280
+++ b/historical/makefiles/smake.huc6280
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_huc6280_tables.c opcodes_huc6280.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_huc6280_tables.o opcodes_huc6280.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o opcodes_huc6280_tables.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o opcodes_huc6280.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_huc6280.o: opcodes_huc6280.c 
+	$(CC) $(CFLAGS) opcodes_huc6280.c
+
+opcodes_huc6280_tables.o: opcodes_huc6280_tables.c 
+	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_huc6280.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_huc6280_tables.o: opcodes_huc6280_tables.c
-	$(CC) $(CFLAGS) opcodes_huc6280_tables.c
-
-opcodes_huc6280.o: opcodes_huc6280.c
-	$(CC) $(CFLAGS) opcodes_huc6280.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.spc700
+++ b/historical/makefiles/smake.spc700
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_spc700_tables.c opcodes_spc700.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_spc700_tables.o opcodes_spc700.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o opcodes_spc700.o opcodes_spc700_tables.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_spc700.o: opcodes_spc700.c 
+	$(CC) $(CFLAGS) opcodes_spc700.c
+
+opcodes_spc700_tables.o: opcodes_spc700_tables.c 
+	$(CC) $(CFLAGS) opcodes_spc700_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_spc700.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_spc700_tables.o: opcodes_spc700_tables.c
-	$(CC) $(CFLAGS) opcodes_spc700_tables.c
-
-opcodes_spc700.o: opcodes_spc700.c
-	$(CC) $(CFLAGS) opcodes_spc700.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/makefiles/smake.z80
+++ b/historical/makefiles/smake.z80
@@ -1,3 +1,7 @@
+###################################################
+# WARNING: This file was automatically generated. #
+###################################################
+
 
 CMATH = MATH=STANDARD
 MATH = m		# math link library designation
@@ -8,65 +12,59 @@ LINKER = slink
 LLIB = LIB LIB:sc$(MATH).lib LIB:sc.lib LIB:amiga.lib
 LFLAGS = STRIPDEBUG NOICONS
 
-CFILES = main.c parse.c include_file.c pass_1.c pass_2.c pass_3.c pass_4.c stack.c listfile.c crc32.c hashmap.c printf.c mersenne_twister.c opcodes_z80_tables.c opcodes_z80.c
-HFILES = main.h parse.h include_file.h pass_1.h pass_2.h pass_3.h pass_4.h stack.h listfile.h crc32.h hashmap.h printf.h mersenne_twister.h defines.h
-OFILES = LIB:c.o main.o parse.o include_file.o pass_1.o pass_2.o pass_3.o pass_4.o stack.o listfile.o crc32.o hashmap.o printf.o mersenne_twister.o opcodes_z80_tables.o opcodes_z80.o
-ALLFILES = $(CFILES) $(HFILES) $(OFILES)
+OFILES = opcodes_z80_tables.o opcodes_z80.o mersenne_twister.o crc32.o hashmap.o stack.o parse.o main.o pass_1.o pass_4.o pass_2.o listfile.o pass_3.o include_file.o printf.o
 
 
 all: main
 
-
-main: $(ALLFILES) smakefile SCOPTIONS
+main: $(OFILES) smakefile SCOPTIONS
 	$(LINKER) $(LFLAGS) FROM $(OFILES) TO wla $(LLIB)
 
 
-main.o: main.c defines.h main.h
+crc32.o: crc32.c crc32.h
+	$(CC) $(CFLAGS) crc32.c
+
+hashmap.o: hashmap.c hashmap.h crc32.h
+	$(CC) $(CFLAGS) hashmap.c
+
+include_file.o: include_file.c include_file.h crc32.h defines.h hashmap.h shared.h parse.h pass_1.h printf.h
+	$(CC) $(CFLAGS) include_file.c
+
+listfile.o: listfile.c listfile.h defines.h hashmap.h shared.h include_file.h
+	$(CC) $(CFLAGS) listfile.c
+
+main.o: main.c main.h defines.h hashmap.h shared.h hashmap.h include_file.h listfile.h mersenne_twister.h parse.h pass_1.h pass_2.h pass_3.h pass_4.h printf.h
 	$(CC) $(CFLAGS) main.c
+
+mersenne_twister.o: mersenne_twister.c mersenne_twister.h
+	$(CC) $(CFLAGS) mersenne_twister.c
+
+opcodes_z80.o: opcodes_z80.c 
+	$(CC) $(CFLAGS) opcodes_z80.c
+
+opcodes_z80_tables.o: opcodes_z80_tables.c 
+	$(CC) $(CFLAGS) opcodes_z80_tables.c
+
+parse.o: parse.c parse.h defines.h hashmap.h shared.h pass_1.h stack.h include_file.h printf.h
+	$(CC) $(CFLAGS) parse.c
+
+pass_1.o: pass_1.c pass_1.h defines.h hashmap.h shared.h main.h include_file.h parse.h pass_2.h pass_3.h stack.h hashmap.h printf.h mersenne_twister.h decode_z80.c
+	$(CC) $(CFLAGS) pass_1.c
+
+pass_2.o: pass_2.c pass_2.h defines.h hashmap.h shared.h pass_1.h pass_4.h hashmap.h printf.h
+	$(CC) $(CFLAGS) pass_2.c
+
+pass_3.o: pass_3.c pass_3.h defines.h hashmap.h shared.h include_file.h printf.h
+	$(CC) $(CFLAGS) pass_3.c
+
+pass_4.o: pass_4.c defines.h hashmap.h shared.h include_file.h listfile.h pass_3.h pass_4.h parse.h stack.h printf.h
+	$(CC) $(CFLAGS) pass_4.c
 
 printf.o: printf.c printf.h
 	$(CC) $(CFLAGS) printf.c
 
-parse.o: parse.c defines.h parse.h
-	$(CC) $(CFLAGS) parse.c
-
-include_file.o: include_file.c defines.h include_file.h
-	$(CC) $(CFLAGS) include_file.c
-
-opcodes_z80_tables.o: opcodes_z80_tables.c
-	$(CC) $(CFLAGS) opcodes_z80_tables.c
-
-opcodes_z80.o: opcodes_z80.c
-	$(CC) $(CFLAGS) opcodes_z80.c
-
-pass_1.o: pass_1.c defines.h pass_1.h parse.h
-	$(CC) $(CFLAGS) pass_1.c
-
-pass_2.o: pass_2.c defines.h pass_2.h
-	$(CC) $(CFLAGS) pass_2.c
-
-pass_3.o: pass_3.c defines.h pass_3.h
-	$(CC) $(CFLAGS) pass_3.c
-
-pass_4.o: pass_4.c defines.h pass_4.h
-	$(CC) $(CFLAGS) pass_4.c $(CMATH)
-
-stack.o: stack.c defines.h stack.h
+stack.o: stack.c stack.h defines.h hashmap.h shared.h hashmap.h parse.h pass_1.h include_file.h printf.h
 	$(CC) $(CFLAGS) stack.c
-
-listfile.o: listfile.c defines.h listfile.h
-	$(CC) $(CFLAGS) listfile.c
-
-crc32.o: crc32.c defines.h crc32.h
-	$(CC) $(CFLAGS) crc32.c
-
-hashmap.o: hashmap.c defines.h hashmap.h
-	$(CC) $(CFLAGS) hashmap.c
-
-mersenne_twister.o: mersenne_twister.c defines.h mersenne_twister.h
-	$(CC) $(CFLAGS) mersenne_twister.c
-
-$(OFILES): $(HFILES)
 
 
 clean:

--- a/historical/msdos.bat
+++ b/historical/msdos.bat
@@ -18,72 +18,72 @@ cd ..
 copy makefiles\makefile.msdos.gb MAKEFILE
 make clean
 make
-move wla-gb.exe binaries\
+move w-gb.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.z80 MAKEFILE
 make
-move wla-z80.exe binaries\
+move w-z80.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.6502 MAKEFILE
 make
-move wla-6502.exe binaries\
+move w-6502.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.65c02 MAKEFILE
 make
-move wla-65c02.exe binaries\
+move w-65c02.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.65ce02 MAKEFILE
 make
-move wla-65ce02.exe binaries\
+move w-65ce02.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.6800 MAKEFILE
 make
-move wla-6800.exe binaries\
+move w-6800.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.6801 MAKEFILE
 make
-move wla-6801.exe binaries\
+move w-6801.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.6809 MAKEFILE
 make
-move wla-6809.exe binaries\
+move w-6809.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.8008 MAKEFILE
 make
-move wla-8008.exe binaries\
+move w-8008.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.8080 MAKEFILE
 make
-move wla-8080.exe binaries\
+move w-8080.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.6510 MAKEFILE
 make
-move wla-6510.exe binaries\
+move w-6510.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.65816 MAKEFILE
 make
-move wla-65816.exe binaries\
+move w-65816.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.spc700 MAKEFILE
 make
-move wla-spc700.exe binaries\
+move w-spc700.exe binaries\
 make clean
 
 copy makefiles\makefile.msdos.huc6280 MAKEFILE
 make
-move wla-huc6280.exe binaries\
+move w-huc6280.exe binaries\
 make clean
 
 cd wlalink

--- a/printf.c
+++ b/printf.c
@@ -32,7 +32,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 */
 
-#ifdef AMIGA
+#if defined(AMIGA) || defined(MSDOS)
 typedef unsigned long uintptr_t;
 typedef long intmax_t;
 #define PRINTF_DISABLE_SUPPORT_LONG_LONG 1


### PR DESCRIPTION
*This PR is a replacement to #394. The generated makefiles do not rely on make extensions and flavors.*

If accepted, this pull request will add an makefile generator python script, and update the makefiles with the generated ones.
For now, only MS-DOS makefiles can be generated but we can add other templates afterwards.

The ideia here is to keep track of the dependencies only on the generator, instead of maintaining each an every historical makefile.

Notable makefile changes:
- `-m` flag (removed from gcc) in favor of `-mtune`.
- `NDEBUG` define added so we have release builds as default.
- Objects now have accurate prerequisites

Additionally, `printf.c` was updated to allow MS-DOS builds.

I was able to *successfully* build WLA 6502, 6510, 6800, 6801, 6809, 8008, 8080, gb and z80.
As before, 65816, 65c02, 65ce02, huc6280, spc700 were not built. I suspect that the target name length plays a role here as all of them result in a .exe that does not comply with the DOS 8dot3 filename limit. Further analysis is needed.