### PR TITLE
Fix test runner warnings

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -38,7 +38,7 @@ fi
 
 SHOW_ALL_OUTPUT="no"
 if [ $# -eq 1 ]; then
-    if [ "$1" == "-v" ]; then
+    if [ "$1" = "-v" ]; then
         SHOW_ALL_OUTPUT="yes"
     fi
 fi
@@ -49,7 +49,7 @@ echo
 echo Running tests...
 cd tests
 
-if [ "$SHOW_ALL_OUTPUT" == "yes" ]; then
+if [ "$SHOW_ALL_OUTPUT" = "yes" ]; then
     echo
 fi
 
@@ -74,7 +74,7 @@ for PLATFORM in */; do
                     echo "********"
                     echo Test \"$TEST\" of platform \"$PLATFORM\" failed.
                     exit 1
-                elif [ "$SHOW_ALL_OUTPUT" == "yes" ]; then
+                elif [ "$SHOW_ALL_OUTPUT" = "yes" ]; then
                     echo "*********************************************************************"
                     echo Test \"$TEST\" of platform \"$PLATFORM\" succeeded:
                     echo "*********************************************************************"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,10 +36,10 @@ if test -f "byte_tester.exe"; then
     BYTE_TESTER="byte_tester.exe"
 fi
 
-SHOW_ALL_OUTPUT="no"
+SHOW_ALL_OUTPUT=false
 if [ $# -eq 1 ]; then
     if [ "$1" = "-v" ]; then
-        SHOW_ALL_OUTPUT="yes"
+        SHOW_ALL_OUTPUT=true
     fi
 fi
 
@@ -49,7 +49,7 @@ echo
 echo Running tests...
 cd tests
 
-if [ "$SHOW_ALL_OUTPUT" = "yes" ]; then
+if $SHOW_ALL_OUTPUT; then
     echo
 fi
 
@@ -74,7 +74,7 @@ for PLATFORM in */; do
                     echo "********"
                     echo Test \"$TEST\" of platform \"$PLATFORM\" failed.
                     exit 1
-                elif [ "$SHOW_ALL_OUTPUT" = "yes" ]; then
+                elif $SHOW_ALL_OUTPUT; then
                     echo "*********************************************************************"
                     echo Test \"$TEST\" of platform \"$PLATFORM\" succeeded:
                     echo "*********************************************************************"


### PR DESCRIPTION
Currently, the test runner script emit warnings on the `sh` shell:
```
Running tests...
./run_tests.sh: 52: [: no: unexpected operator
./run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
../run_tests.sh: 77: [: no: unexpected operator
...
```
Logs on CI job: [Pipelines - Run 20210411.4 logs - Line 6606](https://dev.azure.com/villehelin0486/villehelin/_build/results?buildId=566&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=9c939e41-62c2-5605-5e05-fc3554afc9f5&l=6606)

Those warnings occurs because we're making some comparisons using double equals `==`.

Initially I fixed them just using a single equal sign, but than I noticed that the variable actually holds a boolean value ("yes"/"no"), and thus we can use 1 and 0 exit codes returned by the [true](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/utilities/true.html) and [false](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/utilities/false.html) programs, respectively.   



Resources that helped me:
- https://stackoverflow.com/a/47876317/4202705
- https://www.shellscript.sh/test.html
- https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/utilities/true.html