### PR TITLE
Remove most of g_ind and g_inz usage from pass_1.c

### DIFF
--- a/pass_1.c
+++ b/pass_1.c
@@ -8614,7 +8614,7 @@ int directive_snesemuvector(void) {
 
 int directive_print(void) {
 
-  int get_value, value_type;
+  int get_value, value_type, number_result;
 
   while (1) {
     get_value = NO;
@@ -8635,9 +8635,9 @@ int directive_print(void) {
       get_value = YES;
     }
 
-    g_inz = input_number();
+    number_result = input_number();
 
-    if (g_inz == INPUT_NUMBER_STRING || g_inz == INPUT_NUMBER_ADDRESS_LABEL) {
+    if (number_result == INPUT_NUMBER_STRING || number_result == INPUT_NUMBER_ADDRESS_LABEL) {
       char t[256];
     
       if (get_value == YES) {
@@ -8652,7 +8652,7 @@ int directive_print(void) {
         fflush(stdout);
       }
     }
-    else if (g_inz == SUCCEEDED) {
+    else if (number_result == SUCCEEDED) {
       if (g_quiet == NO) {
         if (value_type == 0)
           printf("%x", g_parsed_int);
@@ -8661,7 +8661,7 @@ int directive_print(void) {
         fflush(stdout);
       }
     }
-    else if (g_inz == INPUT_NUMBER_EOL) {
+    else if (number_result == INPUT_NUMBER_EOL) {
       next_line();
       break;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -5579,14 +5579,14 @@ int directive_rombanks(void) {
 
 int directive_rombankmap(void) {
   
-  int b = 0, a = 0, bt = 0, bt_defined = 0, x, bs = 0, bs_defined = 0, o, q;
+  int b = 0, a = 0, bt = 0, bt_defined = 0, x, bs = 0, bs_defined = 0, o, q, token_result;
 
   no_library_files(".ROMBANKMAP");
 
   /* ROMBANKMAP has been defined previously */
   if (g_rombankmap_defined != 0 || g_rombanks_defined != 0) {
     o = 0;
-    while ((g_ind = get_next_token()) == SUCCEEDED) {
+    while ((token_result = get_next_token()) == SUCCEEDED) {
       /* .IF directive? */
       if (g_tmp[0] == '.') {
         q = parse_if_directive();
@@ -5678,7 +5678,7 @@ int directive_rombankmap(void) {
         }
       }
       else {
-        g_ind = FAILED;
+        token_result = FAILED;
         break;
       }
     }
@@ -5686,7 +5686,7 @@ int directive_rombankmap(void) {
   /* no ROMBANKMAP has been defined */
   else {
     o = 0;
-    while ((g_ind = get_next_token()) == SUCCEEDED) {
+    while ((token_result = get_next_token()) == SUCCEEDED) {
       /* .IF directive? */
       if (g_tmp[0] == '.') {
         q = parse_if_directive();
@@ -5765,13 +5765,13 @@ int directive_rombankmap(void) {
         }
       }
       else {
-        g_ind = FAILED;
+        token_result = FAILED;
         break;
       }
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .ROMBANKMAP data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -5463,7 +5463,7 @@ int directive_name_gb(void) {
 
 int directive_rombanks(void) {
 
-  int q;
+  int i, q, bank_address;
 
   no_library_files(".ROMBANKS");
     
@@ -5516,13 +5516,15 @@ int directive_rombanks(void) {
 
   /* check that the old bank map (smaller) and the new one equal as much as they can */
   if (g_rombanks_defined != 0) {
-    if (g_rombanks < g_parsed_int)
-      g_inz = g_rombanks;
-    else
-      g_inz = g_parsed_int;
+    int bank;
 
-    for (g_ind = 0; g_ind < g_inz; g_ind++) {
-      if (g_banks[g_ind] != g_banksize) {
+    if (g_rombanks < g_parsed_int)
+      bank = g_rombanks;
+    else
+      bank = g_parsed_int;
+
+    for (i = 0; i < bank; i++) {
+      if (g_banks[i] != g_banksize) {
         print_error("The old and the new .ROMBANKMAP's don't match.\n", ERROR_DIR);
         return FAILED;
       }
@@ -5565,10 +5567,10 @@ int directive_rombanks(void) {
     return FAILED;
   }
 
-  for (g_inz = 0, g_ind = 0; g_ind < g_parsed_int; g_ind++) {
-    g_banks[g_ind] = g_banksize;
-    g_bankaddress[g_ind] = g_inz;
-    g_inz += g_banksize;
+  for (bank_address = 0, i = 0; i < g_parsed_int; i++) {
+    g_banks[i] = g_banksize;
+    g_bankaddress[i] = bank_address;
+    bank_address += g_banksize;
   }
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -4354,7 +4354,7 @@ int directive_include(int is_real) {
 int directive_incbin(void) {
 
   struct macro_static *m;
-  int s, r, j, o;
+  int s, r, j, o, id, swap;
 
   if (g_org_defined == 0 && g_output_format != OUTPUT_LIBRARY) {
     print_error("Before you can .INCBIN data you'll need to use ORG.\n", ERROR_LOG);
@@ -4373,12 +4373,12 @@ int directive_incbin(void) {
   /* convert the path string to local enviroment */
   localize_path(g_label);
 
-  if (incbin_file(g_label, &g_ind, &g_inz, &s, &r, &m) == FAILED)
+  if (incbin_file(g_label, &id, &swap, &s, &r, &m) == FAILED)
     return FAILED;
   
   if (m == NULL) {
     /* D [id] [swap] [skip] [size] */
-    fprintf(g_file_out_ptr, "D%d %d %d %d ", g_ind, g_inz, s, r);
+    fprintf(g_file_out_ptr, "D%d %d %d %d ", id, swap, s, r);
   }
   else {
     /* we want to filter the data */
@@ -4392,11 +4392,11 @@ int directive_incbin(void) {
     }
 
     ifd = g_incbin_file_data_first;
-    for (j = 0; j != g_ind; j++)
+    for (j = 0; j != id; j++)
       ifd = ifd->next;
 
     min->data = (unsigned char *)ifd->data;
-    min->swap = g_inz;
+    min->swap = swap;
     min->position = s;
     min->left = r;
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -7606,10 +7606,11 @@ int directive_macro(void) {
     skip_next_token();
 
     while (1) {
-      g_ind = input_next_string();
-      if (g_ind == FAILED)
+      int string_result = input_next_string();
+
+      if (string_result == FAILED)
         return FAILED;
-      if (g_ind == INPUT_NUMBER_EOL) {
+      if (string_result == INPUT_NUMBER_EOL) {
         if (q != 0) {
           next_line();
           break;

--- a/pass_1.c
+++ b/pass_1.c
@@ -1668,7 +1668,6 @@ int enum_add_struct_fields(char *basename, struct structure *st, int reverse) {
 
   char tmp[MAX_NAME_LENGTH * 2 + 5];
   struct structure_item *si;
-  int real_si_size, g;
 
   if (strlen(basename) > MAX_NAME_LENGTH) {
     snprintf(g_error_message, sizeof(g_error_message), "Name \"%s\" is too long!\n", basename);
@@ -1678,7 +1677,7 @@ int enum_add_struct_fields(char *basename, struct structure *st, int reverse) {
 
   si = st->items;
   while (si != NULL) {
-    real_si_size = si->size;
+    int real_si_size = si->size;
     if (si->type == STRUCTURE_ITEM_TYPE_DOTTED)
       real_si_size = 0;
 
@@ -1703,6 +1702,8 @@ int enum_add_struct_fields(char *basename, struct structure *st, int reverse) {
     
     /* if this struct has an .instanceof in it, we need to recurse */
     if (si->type == STRUCTURE_ITEM_TYPE_INSTANCEOF) {
+      int g;
+
       if (si->num_instances <= 1) {
         /* add definition for first (possibly only) instance of struct */
         if (enum_add_struct_fields(tmp, si->instance, 0) == FAILED)

--- a/pass_1.c
+++ b/pass_1.c
@@ -10770,13 +10770,14 @@ int parse_if_directive(void) {
 
   if (strcaselesscmp(g_current_directive, "IFEXISTS") == 0) {
 
+    int number_result;
     FILE *f;
 
     g_expect_calculations = NO;
-    g_inz = input_number();
+    number_result = input_number();
     g_expect_calculations = YES;
 
-    if (g_inz != INPUT_NUMBER_STRING && g_inz != INPUT_NUMBER_ADDRESS_LABEL) {
+    if (number_result != INPUT_NUMBER_STRING && number_result != INPUT_NUMBER_ADDRESS_LABEL) {
       print_error(".IFEXISTS needs a file name string.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -7688,8 +7688,7 @@ int directive_rept_repeat(void) {
   if (compare_next_token("INDEX") == SUCCEEDED) {
     skip_next_token();
 
-    g_ind = input_next_string();
-    if (g_ind != SUCCEEDED)
+    if (input_next_string() != SUCCEEDED)
       return FAILED;
 
     if (redefine(g_tmp, 0.0, NULL, DEFINITION_TYPE_VALUE, 0) == FAILED)

--- a/pass_1.c
+++ b/pass_1.c
@@ -2091,6 +2091,7 @@ int parse_enum_token(void) {
   }
   /* it's an instance of a structure! */
   else if (strcaselesscmp(g_tmp, "INSTANCEOF") == 0) {
+    int number_result;
     type = STRUCTURE_ITEM_TYPE_INSTANCEOF;
 
     if (get_next_token() == FAILED)
@@ -2105,13 +2106,13 @@ int parse_enum_token(void) {
     }
 
     /* get the number of structures to be made */
-    g_inz = input_number();
-    if (g_inz == INPUT_NUMBER_EOL) {
+    number_result = input_number();
+    if (number_result == INPUT_NUMBER_EOL) {
       next_line();
       g_size = st->size;
       g_parsed_int = 1;
     }
-    else if (g_inz == SUCCEEDED) {
+    else if (number_result == SUCCEEDED) {
       if (g_parsed_int < 1) {
         print_error("The number of structures must be greater than 0.\n", ERROR_DIR);
         return FAILED;
@@ -2120,7 +2121,7 @@ int parse_enum_token(void) {
       g_size = st->size * g_parsed_int;
     }
     else {
-      if (g_inz == INPUT_NUMBER_STRING)
+      if (number_result == INPUT_NUMBER_STRING)
         snprintf(g_error_message, sizeof(g_error_message), "Expected the number of structures, got \"%s\" instead.\n", g_label);
       else
         snprintf(g_error_message, sizeof(g_error_message), "Expected the number of structures.\n");

--- a/pass_1.c
+++ b/pass_1.c
@@ -2846,28 +2846,28 @@ int directive_row_data(void) {
 int directive_db_byt_byte(void) {
 
   char bak[256];
-  int o;
+  int char_index, input_number_result;
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
   strcpy(bak, g_current_directive);
 
-  g_inz = input_number();
-  for (g_ind = 0; g_inz == SUCCEEDED || g_inz == INPUT_NUMBER_STRING || g_inz == INPUT_NUMBER_ADDRESS_LABEL || g_inz == INPUT_NUMBER_STACK; g_ind++) {
-    if (g_inz == INPUT_NUMBER_STRING) {
-      for (o = 0; o < g_string_size; o++) {
+  input_number_result = input_number();
+  for (g_ind = 0; input_number_result == SUCCEEDED || input_number_result == INPUT_NUMBER_STRING || input_number_result == INPUT_NUMBER_ADDRESS_LABEL || input_number_result == INPUT_NUMBER_STACK; g_ind++) {
+    if (input_number_result == INPUT_NUMBER_STRING) {
+      for (char_index = 0; char_index < g_string_size; char_index++) {
         /* handle '\0' */
-        if (g_label[o] == '\\' && g_label[o + 1] == '0') {
+        if (g_label[char_index] == '\\' && g_label[char_index + 1] == '0') {
           fprintf(g_file_out_ptr, "d%d ", '\0');
-          o++;
+          char_index++;
         }
         /* handle '\x' */
-        else if (g_label[o] == '\\' && g_label[o + 1] == 'x') {
+        else if (g_label[char_index] == '\\' && g_label[char_index + 1] == 'x') {
           char tmp_a[8], *tmp_b;
           int tmp_c;
         
-          o += 3;
-          snprintf(tmp_a, sizeof(tmp_a), "%c%c", g_label[o-1], g_label[o]);
+          char_index += 3;
+          snprintf(tmp_a, sizeof(tmp_a), "%c%c", g_label[char_index-1], g_label[char_index]);
           tmp_c = (int)strtol(tmp_a, &tmp_b, 16);
           if (*tmp_b) {
             snprintf(g_error_message, sizeof(g_error_message), ".%s '\\x' needs hexadecimal byte (00-FF) data.\n", bak);
@@ -2877,63 +2877,63 @@ int directive_db_byt_byte(void) {
           fprintf(g_file_out_ptr, "d%d ", tmp_c);
         }
         /* handle '\<' */
-        else if (g_label[o] == '\\' && g_label[o + 1] == '<') {
-          o += 2;
-          if (o == g_string_size) {
+        else if (g_label[char_index] == '\\' && g_label[char_index + 1] == '<') {
+          char_index += 2;
+          if (char_index == g_string_size) {
             snprintf(g_error_message, sizeof(g_error_message), ".%s '\\<' needs character data.\n", bak);
             print_error(g_error_message, ERROR_INP);
             return FAILED;
           }
-          fprintf(g_file_out_ptr, "d%d ", (int)g_label[o]|0x80);
+          fprintf(g_file_out_ptr, "d%d ", (int)g_label[char_index]|0x80);
         }
         /* handle '\>' */
-        else if (g_label[o] == '\\' && g_label[o + 1] == '>' && o == 0) {
+        else if (g_label[char_index] == '\\' && g_label[char_index + 1] == '>' && char_index == 0) {
           snprintf(g_error_message, sizeof(g_error_message), ".%s '\\>' needs character data.\n", bak);
           print_error(g_error_message, ERROR_INP);
           return FAILED;
         }
-        else if (g_label[o + 1] == '\\' && g_label[o + 2] == '>') {
-          fprintf(g_file_out_ptr, "d%d ", (int)g_label[o]|0x80);
-          o += 2;
+        else if (g_label[char_index + 1] == '\\' && g_label[char_index + 2] == '>') {
+          fprintf(g_file_out_ptr, "d%d ", (int)g_label[char_index]|0x80);
+          char_index += 2;
         }
         /* handle '\\' */
-        else if (g_label[o] == '\\' && g_label[o + 1] == '\\') {
+        else if (g_label[char_index] == '\\' && g_label[char_index + 1] == '\\') {
           fprintf(g_file_out_ptr, "d%d ", '\\');
-          o++;
+          char_index++;
         }
         else
-          fprintf(g_file_out_ptr, "d%d ", (int)g_label[o]);
+          fprintf(g_file_out_ptr, "d%d ", (int)g_label[char_index]);
       }
-      g_inz = input_number();
+      input_number_result = input_number();
       continue;
     }
 
-    if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+    if (input_number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
       snprintf(g_error_message, sizeof(g_error_message), ".%s expects 8-bit data, %d is out of range!\n", bak, g_parsed_int);
       print_error(g_error_message, ERROR_DIR);
       return FAILED;
     }
 
-    if (g_inz == SUCCEEDED)
+    if (input_number_result == SUCCEEDED)
       fprintf(g_file_out_ptr, "d%d ", g_parsed_int);
-    else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+    else if (input_number_result == INPUT_NUMBER_ADDRESS_LABEL)
       fprintf(g_file_out_ptr, "Q%s ", g_label);
-    else if (g_inz == INPUT_NUMBER_STACK)
+    else if (input_number_result == INPUT_NUMBER_STACK)
       fprintf(g_file_out_ptr, "c%d ", g_latest_stack);
 
-    g_inz = input_number();
+    input_number_result = input_number();
   }
 
-  if (g_inz == FAILED)
+  if (input_number_result == FAILED)
     return FAILED;
 
-  if (g_inz == INPUT_NUMBER_EOL && g_ind == 0) {
+  if (input_number_result == INPUT_NUMBER_EOL && g_ind == 0) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", bak);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
   }
 
-  if (g_inz == INPUT_NUMBER_EOL)
+  if (input_number_result == INPUT_NUMBER_EOL)
     next_line();
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -4076,7 +4076,7 @@ int directive_dstruct(void) {
 int directive_dsb_ds(void) {
 
   char bak[256];
-  int q;
+  int q, parsed_int;
   
   strcpy(bak, g_current_directive);
 
@@ -4095,7 +4095,7 @@ int directive_dsb_ds(void) {
     return FAILED;
   }
 
-  g_inz = g_parsed_int;
+  parsed_int = g_parsed_int;
 
   q = input_number();
   if (q == FAILED)
@@ -4113,14 +4113,14 @@ int directive_dsb_ds(void) {
   }
 
   if (q == SUCCEEDED)
-    fprintf(g_file_out_ptr, "x%d %d ", g_inz, g_parsed_int);
+    fprintf(g_file_out_ptr, "x%d %d ", parsed_int, g_parsed_int);
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "R%s ", g_label);
   }
   else if (q == INPUT_NUMBER_STACK) {
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "c%d ", g_latest_stack);
   }
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -8173,7 +8173,7 @@ int directive_snesheader(void) {
 int directive_snesnativevector(void) {
   
   int cop_defined = 0, brk_defined = 0, abort_defined = 0, base_address = 0;
-  int nmi_defined = 0, unused_defined = 0, irq_defined = 0, q;
+  int nmi_defined = 0, unused_defined = 0, irq_defined = 0, q, token_result;
   char cop[512], brk[512], abort[512], nmi[512], unused[512], irq[512];
 
   if (g_snesnativevector_defined != 0) {
@@ -8205,7 +8205,7 @@ int directive_snesnativevector(void) {
   fprintf(g_file_out_ptr, "P O0 A%d %d ", g_sec_tmp->id, base_address);
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -8235,150 +8235,162 @@ int directive_snesnativevector(void) {
       break;
     }
     else if (strcaselesscmp(g_tmp, "COP") == 0) {
+      int number_result;
+
       if (cop_defined != 0) {
         print_error("COP can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "COP expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(cop, sizeof(cop), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(cop, sizeof(cop), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(cop, sizeof(cop), "C%d ", g_latest_stack);
 
       cop_defined++;
     }
     else if (strcaselesscmp(g_tmp, "BRK") == 0) {
+      int number_result;
+
       if (brk_defined != 0) {
         print_error("BRK can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "BRK expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(brk, sizeof(brk), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(brk, sizeof(brk), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(brk, sizeof(brk), "C%d ", g_latest_stack);
 
       brk_defined++;
     }
     else if (strcaselesscmp(g_tmp, "ABORT") == 0) {
+      int number_result;
+
       if (abort_defined != 0) {
         print_error("ABORT can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "ABORT expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(abort, sizeof(abort), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(abort, sizeof(abort), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(abort, sizeof(abort), "C%d ", g_latest_stack);
 
       abort_defined++;
     }
     else if (strcaselesscmp(g_tmp, "NMI") == 0) {
+      int number_result;
+
       if (nmi_defined != 0) {
         print_error("NMI can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "NMI expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(nmi, sizeof(nmi), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(nmi, sizeof(nmi), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(nmi, sizeof(nmi), "C%d ", g_latest_stack);
 
       nmi_defined++;
     }
     else if (strcaselesscmp(g_tmp, "UNUSED") == 0) {
+      int number_result;
+
       if (unused_defined != 0) {
         print_error("UNUSED can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "UNUSED expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(unused, sizeof(unused), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(unused, sizeof(unused), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(unused, sizeof(unused), "C%d ", g_latest_stack);
 
       unused_defined++;
     }
     else if (strcaselesscmp(g_tmp, "IRQ") == 0) {
+      int number_result;
+
       if (irq_defined != 0) {
         print_error("IRQ can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "IRQ expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(irq, sizeof(irq), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(irq, sizeof(irq), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(irq, sizeof(irq), "C%d ", g_latest_stack);
 
       irq_defined++;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .SNESNATIVEVECTOR data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -6151,7 +6151,7 @@ int directive_background(void) {
 
 int directive_gbheader(void) {
 
-  int q;
+  int q, token_result;
     
   if (g_gbheader_defined != 0) {
     print_error(".GBHEADER can be defined only once.\n", ERROR_DIR);
@@ -6173,7 +6173,7 @@ int directive_gbheader(void) {
     return FAILED;
   }
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -6233,40 +6233,44 @@ int directive_gbheader(void) {
       g_romsgb++;
     }
     else if (strcaselesscmp(g_tmp, "NAME") == 0) {
-      if ((g_ind = get_next_token()) == FAILED)
+      if ((token_result = get_next_token()) == FAILED)
         return FAILED;
 
-      if (g_ind != GET_NEXT_TOKEN_STRING) {
+      if (token_result != GET_NEXT_TOKEN_STRING) {
         print_error("NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
         return FAILED;
       }
 
       /* no name has been defined so far */
       if (g_name_defined == 0) {
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_ind < 16; g_ind++)
-          g_name[g_ind] = g_tmp[g_ind];
+        int i;
+
+        for (i = 0; g_tmp[i] != 0 && i < 16; i++)
+          g_name[i] = g_tmp[i];
     
-        if (g_ind == 16 && g_tmp[g_ind] != 0) {
+        if (i == 16 && g_tmp[i] != 0) {
           print_error("NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
           return FAILED;
         }
 
-        for ( ; g_ind < 16; g_name[g_ind] = 0, g_ind++)
+        for ( ; i < 16; g_name[i] = 0, i++)
           ;
 
         g_name_defined = 1;
       }
       else {
+        int i;
+
         /* compare the names */
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_name[g_ind] != 0 && g_ind < 16; g_ind++)
-          if (g_name[g_ind] != g_tmp[g_ind])
+        for (i = 0; g_tmp[i] != 0 && g_name[i] != 0 && i < 16; i++)
+          if (g_name[i] != g_tmp[i])
             break;
     
-        if (g_ind == 16 && g_tmp[g_ind] != 0) {
+        if (i == 16 && g_tmp[i] != 0) {
           print_error("NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
           return FAILED;
         }
-        if (g_ind != 16 && (g_name[g_ind] != 0 || g_tmp[g_ind] != 0)) {
+        if (i != 16 && (g_name[i] != 0 || g_tmp[i] != 0)) {
           print_error("NAME was already defined.\n", ERROR_DIR);
           return FAILED;
         }
@@ -6304,10 +6308,10 @@ int directive_gbheader(void) {
         return FAILED;
       }
 
-      if ((g_ind = get_next_token()) == FAILED)
+      if ((token_result = get_next_token()) == FAILED)
         return FAILED;
 
-      if (g_ind != GET_NEXT_TOKEN_STRING) {
+      if (token_result != GET_NEXT_TOKEN_STRING) {
         print_error(".LICENSEECODENEW requires a string of two letters.\n", ERROR_DIR);
         return FAILED;
       }
@@ -6328,14 +6332,14 @@ int directive_gbheader(void) {
       g_licenseecodenew_defined = 1;
     }
     else if (strcaselesscmp(g_tmp, "CARTRIDGETYPE") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "CARTRIDGETYPE needs a 8-bit value, got %d.\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_cartridgetype_defined != 0 && g_cartridgetype != g_parsed_int) {
           print_error("CARTRIDGETYPE was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -6348,14 +6352,14 @@ int directive_gbheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "RAMSIZE") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "RAMSIZE needs a 8-bit value, got %d.\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_rambanks_defined != 0 && g_rambanks != g_parsed_int) {
           print_error("RAMSIZE was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -6368,14 +6372,14 @@ int directive_gbheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "COUNTRYCODE") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
       
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "COUNTRYCODE needs a non-negative value, got %d.\n\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_countrycode_defined != 0 && g_countrycode != g_parsed_int) {
           print_error("COUNTRYCODE was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -6388,14 +6392,14 @@ int directive_gbheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "DESTINATIONCODE") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "DESTINATIONCODE needs a non-negative value, got %d.\n\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_countrycode_defined != 0 && g_countrycode != g_parsed_int) {
           print_error("DESTINATIONCODE was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -6408,14 +6412,14 @@ int directive_gbheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "VERSION") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "VERSION needs a non-negative value, got %d.\n\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_version_defined != 0 && g_version != g_parsed_int) {
           print_error("VERSION was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -6428,12 +6432,12 @@ int directive_gbheader(void) {
         return FAILED;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .GBHEADER data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -2848,15 +2848,15 @@ int directive_row_data(void) {
 int directive_db_byt_byte(void) {
 
   char bak[256];
-  int char_index, input_number_result;
+  int i, char_index, number_result;
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
   strcpy(bak, g_current_directive);
 
-  input_number_result = input_number();
-  for (g_ind = 0; input_number_result == SUCCEEDED || input_number_result == INPUT_NUMBER_STRING || input_number_result == INPUT_NUMBER_ADDRESS_LABEL || input_number_result == INPUT_NUMBER_STACK; g_ind++) {
-    if (input_number_result == INPUT_NUMBER_STRING) {
+  number_result = input_number();
+  for (i = 0; number_result == SUCCEEDED || number_result == INPUT_NUMBER_STRING || number_result == INPUT_NUMBER_ADDRESS_LABEL || number_result == INPUT_NUMBER_STACK; i++) {
+    if (number_result == INPUT_NUMBER_STRING) {
       for (char_index = 0; char_index < g_string_size; char_index++) {
         /* handle '\0' */
         if (g_label[char_index] == '\\' && g_label[char_index + 1] == '0') {
@@ -2906,36 +2906,36 @@ int directive_db_byt_byte(void) {
         else
           fprintf(g_file_out_ptr, "d%d ", (int)g_label[char_index]);
       }
-      input_number_result = input_number();
+      number_result = input_number();
       continue;
     }
 
-    if (input_number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+    if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
       snprintf(g_error_message, sizeof(g_error_message), ".%s expects 8-bit data, %d is out of range!\n", bak, g_parsed_int);
       print_error(g_error_message, ERROR_DIR);
       return FAILED;
     }
 
-    if (input_number_result == SUCCEEDED)
+    if (number_result == SUCCEEDED)
       fprintf(g_file_out_ptr, "d%d ", g_parsed_int);
-    else if (input_number_result == INPUT_NUMBER_ADDRESS_LABEL)
+    else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
       fprintf(g_file_out_ptr, "Q%s ", g_label);
-    else if (input_number_result == INPUT_NUMBER_STACK)
+    else if (number_result == INPUT_NUMBER_STACK)
       fprintf(g_file_out_ptr, "c%d ", g_latest_stack);
 
-    input_number_result = input_number();
+    number_result = input_number();
   }
 
-  if (input_number_result == FAILED)
+  if (number_result == FAILED)
     return FAILED;
 
-  if (input_number_result == INPUT_NUMBER_EOL && g_ind == 0) {
+  if (number_result == INPUT_NUMBER_EOL && i == 0) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", bak);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
   }
 
-  if (input_number_result == INPUT_NUMBER_EOL)
+  if (number_result == INPUT_NUMBER_EOL)
     next_line();
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -5407,43 +5407,49 @@ int directive_shift(void) {
 #ifdef GB
 
 int directive_name_gb(void) {
-      
+
+  int token_result;
+
   no_library_files(".NAME");
   
-  if ((g_ind = get_next_token()) == FAILED)
+  if ((token_result = get_next_token()) == FAILED)
     return FAILED;
 
-  if (g_ind != GET_NEXT_TOKEN_STRING) {
+  if (token_result != GET_NEXT_TOKEN_STRING) {
     print_error(".NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
     return FAILED;
   }
 
   /* no name has been defined so far */
   if (g_name_defined == 0) {
-    for (g_ind = 0; g_tmp[g_ind] != 0 && g_ind < 16; g_ind++)
-      g_name[g_ind] = g_tmp[g_ind];
+    int i;
 
-    if (g_ind == 16 && g_tmp[g_ind] != 0) {
+    for (i = 0; g_tmp[i] != 0 && i < 16; i++)
+      g_name[i] = g_tmp[i];
+
+    if (i == 16 && g_tmp[i] != 0) {
       print_error(".NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
       return FAILED;
     }
 
-    for ( ; g_ind < 16; g_name[g_ind] = 0, g_ind++)
+    for ( ; i < 16; g_name[i] = 0, i++)
       ;
 
     g_name_defined = 1;
   }
   /* compare the names */
   else {
-    for (g_ind = 0; g_tmp[g_ind] != 0 && g_name[g_ind] != 0 && g_ind < 16; g_ind++)
-      if (g_name[g_ind] != g_tmp[g_ind])
+    int i;
+
+    for (i = 0; g_tmp[i] != 0 && g_name[i] != 0 && i < 16; i++)
+      if (g_name[i] != g_tmp[i])
         break;
 
-    if (g_ind == 16 && g_tmp[g_ind] != 0) {
+    if (i == 16 && g_tmp[i] != 0) {
       print_error(".NAME requires a string of 1 to 16 letters.\n", ERROR_DIR);
       return FAILED;
     }
-    if (g_ind != 16 && (g_name[g_ind] != 0 || g_tmp[g_ind] != 0)) {
+    if (i != 16 && (g_name[i] != 0 || g_tmp[i] != 0)) {
       print_error(".NAME was already defined.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -8393,7 +8393,7 @@ int directive_snesnativevector(void) {
 int directive_snesemuvector(void) {
   
   int cop_defined = 0, unused_defined = 0, abort_defined = 0, base_address = 0;
-  int nmi_defined = 0, reset_defined = 0, irqbrk_defined = 0, q;
+  int nmi_defined = 0, reset_defined = 0, irqbrk_defined = 0, q, token_result;
   char cop[512], unused[512], abort[512], nmi[512], reset[512], irqbrk[512];
 
   if (g_snesemuvector_defined != 0) {
@@ -8425,7 +8425,7 @@ int directive_snesemuvector(void) {
   fprintf(g_file_out_ptr, "P O0 A%d %d ", g_sec_tmp->id, base_address);
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -8455,150 +8455,162 @@ int directive_snesemuvector(void) {
       break;
     }
     else if (strcaselesscmp(g_tmp, "COP") == 0) {
+      int number_result;
+
       if (cop_defined != 0) {
         print_error("COP can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "COP expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(cop, sizeof(cop), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(cop, sizeof(cop), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(cop, sizeof(cop), "C%d ", g_latest_stack);
 
       cop_defined++;
     }
     else if (strcaselesscmp(g_tmp, "RESET") == 0) {
+      int number_result;
+
       if (reset_defined != 0) {
         print_error("RESET can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "RESET expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(reset, sizeof(reset), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(reset, sizeof(reset), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(reset, sizeof(reset), "C%d ", g_latest_stack);
 
       reset_defined++;
     }
     else if (strcaselesscmp(g_tmp, "ABORT") == 0) {
+      int number_result;
+
       if (abort_defined != 0) {
         print_error("ABORT can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "ABORT expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(abort, sizeof(abort), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(abort, sizeof(abort), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(abort, sizeof(abort), "C%d ", g_latest_stack);
 
       abort_defined++;
     }
     else if (strcaselesscmp(g_tmp, "NMI") == 0) {
+      int number_result;
+
       if (nmi_defined != 0) {
         print_error("NMI can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "NMI expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(nmi, sizeof(nmi), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(nmi, sizeof(nmi), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(nmi, sizeof(nmi), "C%d ", g_latest_stack);
 
       nmi_defined++;
     }
     else if (strcaselesscmp(g_tmp, "UNUSED") == 0) {
+      int number_result;
+
       if (unused_defined != 0) {
         print_error("UNUSED can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "UNUSED expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(unused, sizeof(unused), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(unused, sizeof(unused), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(unused, sizeof(unused), "C%d ", g_latest_stack);
 
       unused_defined++;
     }
     else if (strcaselesscmp(g_tmp, "IRQBRK") == 0) {
+      int number_result;
+
       if (irqbrk_defined != 0) {
         print_error("IRQBRK can only be defined once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
       
-      if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
         snprintf(g_error_message, sizeof(g_error_message), "IRQBRK expects 16-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
 
-      if (g_inz == SUCCEEDED)
+      if (number_result == SUCCEEDED)
         snprintf(irqbrk, sizeof(irqbrk), "y%d ", g_parsed_int);
-      else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+      else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
         snprintf(irqbrk, sizeof(irqbrk), "k%d r%s ", g_active_file_info_last->line_current, g_label);
-      else if (g_inz == INPUT_NUMBER_STACK)
+      else if (number_result == INPUT_NUMBER_STACK)
         snprintf(irqbrk, sizeof(irqbrk), "C%d ", g_latest_stack);
 
       irqbrk_defined++;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
   
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .SNESEMUVECTOR data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -3573,43 +3573,49 @@ int directive_dsd(void) {
 #if defined(W65816)
 
 int directive_name_w65816(void) {
-    
+
+  int token_result;
+
   no_library_files(".NAME");
 
-  if ((g_ind = get_next_token()) == FAILED)
+  if ((token_result = get_next_token()) == FAILED)
     return FAILED;
 
-  if (g_ind != GET_NEXT_TOKEN_STRING) {
+  if (token_result != GET_NEXT_TOKEN_STRING) {
     print_error(".NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
     return FAILED;
   }
 
   /* no name has been defined so far */
   if (g_name_defined == 0) {
-    for (g_ind = 0; g_tmp[g_ind] != 0 && g_ind < 21; g_ind++)
-      g_name[g_ind] = g_tmp[g_ind];
+    int i;
 
-    if (g_ind == 21 && g_tmp[g_ind] != 0) {
+    for (i = 0; g_tmp[i] != 0 && i < 21; i++)
+      g_name[i] = g_tmp[i];
+
+    if (i == 21 && g_tmp[i] != 0) {
       print_error(".NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
       return FAILED;
     }
 
-    for ( ; g_ind < 21; g_name[g_ind] = 0, g_ind++)
+    for ( ; i < 21; g_name[i] = 0, i++)
       ;
 
     g_name_defined = 1;
   }
   else {
+    int i;
+
     /* compare the names */
-    for (g_ind = 0; g_tmp[g_ind] != 0 && g_name[g_ind] != 0 && g_ind < 21; g_ind++)
-      if (g_name[g_ind] != g_tmp[g_ind])
+    for (i = 0; g_tmp[i] != 0 && g_name[i] != 0 && i < 21; i++)
+      if (g_name[i] != g_tmp[i])
         break;
 
-    if (g_ind == 21 && g_tmp[g_ind] != 0) {
+    if (i == 21 && g_tmp[i] != 0) {
       print_error(".NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
       return FAILED;
     }
-    if (g_ind != 21 && (g_name[g_ind] != 0 || g_tmp[g_ind] != 0)) {
+    if (i != 21 && (g_name[i] != 0 || g_tmp[i] != 0)) {
       print_error(".NAME was already defined.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -3382,40 +3382,41 @@ int directive_dw_word_addr(void) {
 
 int directive_dl_long_faraddr(void) {
 
+  int i, number_result;
   char bak[256];
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
   strcpy(bak, g_current_directive);
 
-  g_inz = input_number();
-  for (g_ind = 0; g_inz == SUCCEEDED || g_inz == INPUT_NUMBER_ADDRESS_LABEL || g_inz == INPUT_NUMBER_STACK; g_ind++) {
-    if (g_inz == SUCCEEDED && (g_parsed_int < -8388608 || g_parsed_int > 16777215)) {
+  number_result = input_number();
+  for (i = 0; number_result == SUCCEEDED || number_result == INPUT_NUMBER_ADDRESS_LABEL || number_result == INPUT_NUMBER_STACK; i++) {
+    if (number_result == SUCCEEDED && (g_parsed_int < -8388608 || g_parsed_int > 16777215)) {
       snprintf(g_error_message, sizeof(g_error_message), ".%s expects 24-bit data, %d is out of range!\n", bak, g_parsed_int);
       print_error(g_error_message, ERROR_DIR);
       return FAILED;
     }
 
-    if (g_inz == SUCCEEDED)
+    if (number_result == SUCCEEDED)
       fprintf(g_file_out_ptr, "z%d ", g_parsed_int);
-    else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+    else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
       fprintf(g_file_out_ptr, "q%s ", g_label);
-    else if (g_inz == INPUT_NUMBER_STACK)
+    else if (number_result == INPUT_NUMBER_STACK)
       fprintf(g_file_out_ptr, "T%d ", g_latest_stack);
 
-    g_inz = input_number();
+    number_result = input_number();
   }
 
-  if (g_inz == FAILED)
+  if (number_result == FAILED)
     return FAILED;
 
-  if ((g_inz == INPUT_NUMBER_EOL || g_inz == INPUT_NUMBER_STRING) && g_ind == 0) {
+  if ((number_result == INPUT_NUMBER_EOL || number_result == INPUT_NUMBER_STRING) && i == 0) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", bak);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
   }
 
-  if (g_inz == INPUT_NUMBER_EOL)
+  if (number_result == INPUT_NUMBER_EOL)
     next_line();
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -3520,7 +3520,7 @@ int directive_dd(void) {
 
 int directive_dsd(void) {
 
-  int q;
+  int q, parsed_int;
   
   q = input_number();
   if (q == FAILED)
@@ -3536,7 +3536,7 @@ int directive_dsd(void) {
     return FAILED;
   }
 
-  g_inz = g_parsed_int;
+  parsed_int = g_parsed_int;
 
   q = input_number();
   if (q == FAILED)
@@ -3555,14 +3555,14 @@ int directive_dsd(void) {
   */
 
   if (q == SUCCEEDED)
-    fprintf(g_file_out_ptr, "w%d %d ", g_inz, g_parsed_int);
+    fprintf(g_file_out_ptr, "w%d %d ", parsed_int, g_parsed_int);
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "V%s ", g_label);
   }
   else if (q == INPUT_NUMBER_STACK) {
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "U%d ", g_latest_stack);
   }
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -3339,40 +3339,41 @@ int directive_asc(void) {
 
 int directive_dw_word_addr(void) {
 
+  int i, number_result;
   char bak[256];
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
   strcpy(bak, g_current_directive);
 
-  g_inz = input_number();
-  for (g_ind = 0; g_inz == SUCCEEDED || g_inz == INPUT_NUMBER_ADDRESS_LABEL || g_inz == INPUT_NUMBER_STACK; g_ind++) {
-    if (g_inz == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
+  number_result = input_number();
+  for (i = 0; number_result == SUCCEEDED || number_result == INPUT_NUMBER_ADDRESS_LABEL || number_result == INPUT_NUMBER_STACK; i++) {
+    if (number_result == SUCCEEDED && (g_parsed_int < -32768 || g_parsed_int > 65535)) {
       snprintf(g_error_message, sizeof(g_error_message), ".%s expects 16-bit data, %d is out of range!\n", bak, g_parsed_int);
       print_error(g_error_message, ERROR_DIR);
       return FAILED;
     }
 
-    if (g_inz == SUCCEEDED)
+    if (number_result == SUCCEEDED)
       fprintf(g_file_out_ptr, "y%d", g_parsed_int);
-    else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+    else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
       fprintf(g_file_out_ptr, "r%s ", g_label);
-    else if (g_inz == INPUT_NUMBER_STACK)
+    else if (number_result == INPUT_NUMBER_STACK)
       fprintf(g_file_out_ptr, "C%d ", g_latest_stack);
 
-    g_inz = input_number();
+    number_result = input_number();
   }
 
-  if (g_inz == FAILED)
+  if (number_result == FAILED)
     return FAILED;
 
-  if ((g_inz == INPUT_NUMBER_EOL || g_inz == INPUT_NUMBER_STRING) && g_ind == 0) {
+  if ((number_result == INPUT_NUMBER_EOL || number_result == INPUT_NUMBER_STRING) && i == 0) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", bak);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
   }
 
-  if (g_inz == INPUT_NUMBER_EOL)
+  if (number_result == INPUT_NUMBER_EOL)
     next_line();
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -4937,8 +4937,7 @@ int directive_section(void) {
     if (skip_next_token() == FAILED)
       return FAILED;
 
-    g_inz = input_number();
-    if (g_inz != SUCCEEDED) {
+    if (input_number() != SUCCEEDED) {
       print_error("Could not parse the SIZE.\n", ERROR_DIR);
       return FAILED;
     }
@@ -4957,8 +4956,7 @@ int directive_section(void) {
     if (skip_next_token() == FAILED)
       return FAILED;
 
-    g_inz = input_number();
-    if (g_inz != SUCCEEDED) {
+    if (input_number() != SUCCEEDED) {
       print_error("Could not parse the .SECTION alignment.\n", ERROR_DIR);
       return FAILED;
     }
@@ -4971,8 +4969,7 @@ int directive_section(void) {
     if (skip_next_token() == FAILED)
       return FAILED;
 
-    g_inz = input_number();
-    if (g_inz != SUCCEEDED) {
+    if (input_number() != SUCCEEDED) {
       print_error("Could not parse the .SECTION offset.\n", ERROR_DIR);
       return FAILED;
     }
@@ -5090,8 +5087,7 @@ int directive_section(void) {
     if (skip_next_token() == FAILED)
       return FAILED;
 
-    g_inz = input_number();
-    if (g_inz != SUCCEEDED) {
+    if (input_number() != SUCCEEDED) {
       print_error("Could not parse the .SECTION priority.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -5854,7 +5854,7 @@ int directive_rombankmap(void) {
 
 int directive_memorymap(void) {
   
-  int slotsize = 0, slotsize_defined = 0, s = 0, q, o;
+  int slotsize = 0, slotsize_defined = 0, s = 0, q, o, token_result;
 
   if (g_memorymap_defined == 1) {
     print_error(".MEMORYMAP can be defined only once.\n", ERROR_DIR);
@@ -5863,7 +5863,7 @@ int directive_memorymap(void) {
   if (g_output_format == OUTPUT_LIBRARY)
     print_error("Libraries don't need .MEMORYMAP.\n", ERROR_WRN);
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -6006,12 +6006,12 @@ int directive_memorymap(void) {
       s++;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .MEMORYMAP data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -5311,11 +5311,12 @@ int directive_fread(void) {
 int directive_block(void) {
 
   struct block_name *b;
+  int token_result;
   
-  if ((g_ind = get_next_token()) == FAILED)
+  if ((token_result = get_next_token()) == FAILED)
     return FAILED;
 
-  if (g_ind != GET_NEXT_TOKEN_STRING) {
+  if (token_result != GET_NEXT_TOKEN_STRING) {
     print_error(".BLOCK requires a name string.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -3086,7 +3086,7 @@ int directive_bits(void) {
 
 int directive_asctable_asciitable(void) {
   
-  int astart, aend, q, o;
+  int astart, aend, q, o, token_result;
   char bak[256];
   
   strcpy(bak, g_current_directive);
@@ -3096,7 +3096,7 @@ int directive_asctable_asciitable(void) {
     g_asciitable[o] = o;
 
   /* read the entries */
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -3172,7 +3172,7 @@ int directive_asctable_asciitable(void) {
 
       /* skip the "=" */
       if (compare_next_token("=") != SUCCEEDED) {
-        g_ind = FAILED;
+        token_result = FAILED;
         break;
       }
       skip_next_token();
@@ -3201,12 +3201,12 @@ int directive_asctable_asciitable(void) {
       }
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     snprintf(g_error_message, sizeof(g_error_message), "Error in .%s data structure.\n", bak);
     print_error(g_error_message, ERROR_DIR);
     return FAILED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -8677,11 +8677,12 @@ int directive_print(void) {
 
 int directive_printt(void) {
   
+  int number_result;
   char t[256];
     
-  g_inz = input_number();
+  number_result = input_number();
 
-  if (g_inz != INPUT_NUMBER_STRING && g_inz != INPUT_NUMBER_ADDRESS_LABEL) {
+  if (number_result != INPUT_NUMBER_STRING && number_result != INPUT_NUMBER_ADDRESS_LABEL) {
     print_error(".PRINTT needs a string/label.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -2957,12 +2957,12 @@ static int _char_to_hex(char e) {
 
 int directive_hex(void) {
 
-  int o, nybble_1 = 0, nybble_2 = 0, error;
+  int i, o, nybble_1 = 0, nybble_2 = 0, error, number_result;
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
-  g_inz = input_number();
-  for (g_ind = 0; g_inz == INPUT_NUMBER_STRING; g_ind++) {
+  number_result = input_number();
+  for (i = 0; number_result == INPUT_NUMBER_STRING; i++) {
     if ((g_string_size & 1) == 1) {
       print_error("The string length for .HEX must be a multiple of 2.\n", ERROR_INP);
       return FAILED;
@@ -2992,18 +2992,18 @@ int directive_hex(void) {
       fprintf(g_file_out_ptr, "d%d ", (nybble_1 << 4) | nybble_2);
     }
 
-    g_inz = input_number();
+    number_result = input_number();
   }
 
-  if (g_inz == FAILED)
+  if (number_result == FAILED)
     return FAILED;
 
-  if (g_inz == INPUT_NUMBER_EOL && g_ind == 0) {
+  if (number_result == INPUT_NUMBER_EOL && i == 0) {
     print_error(".HEX needs data.\n", ERROR_INP);
     return FAILED;
   }
 
-  if (g_inz == INPUT_NUMBER_EOL)
+  if (number_result == INPUT_NUMBER_EOL)
     next_line();
   else {
     print_error(".HEX takes only strings.\n", ERROR_INP);

--- a/pass_1.c
+++ b/pass_1.c
@@ -4130,7 +4130,7 @@ int directive_dsb_ds(void) {
 
 int directive_dsw(void) {
 
-  int q;
+  int q, parsed_int;
 
   q = input_number();
   if (q == FAILED)
@@ -4146,7 +4146,7 @@ int directive_dsw(void) {
     return FAILED;
   }
 
-  g_inz = g_parsed_int;
+  parsed_int = g_parsed_int;
 
   q = input_number();
   if (q == FAILED)
@@ -4163,14 +4163,14 @@ int directive_dsw(void) {
   }
 
   if (q == SUCCEEDED)
-    fprintf(g_file_out_ptr, "X%d %d ", g_inz, g_parsed_int);
+    fprintf(g_file_out_ptr, "X%d %d ", parsed_int, g_parsed_int);
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "r%s ", g_label);
   }
   else if (q == INPUT_NUMBER_STACK) {
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "C%d ", g_latest_stack);
   }
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -3220,7 +3220,7 @@ int directive_asctable_asciitable(void) {
 
 int directive_asc(void) {
 
-  int o, q, map_only_strings = NO;
+  int o, map_only_strings = NO;
   char bak[256];
 
   strcpy(bak, g_current_directive);
@@ -3235,6 +3235,8 @@ int directive_asc(void) {
   }
 
   while (1) {
+    int character, q;
+
     q = input_number();
     if (q == INPUT_NUMBER_EOL) {
       next_line();
@@ -3244,11 +3246,11 @@ int directive_asc(void) {
     if (q == INPUT_NUMBER_STRING) {
       /* remap the ascii string */
       for (o = 0; o < g_string_size; o++) {
-        g_ind = g_label[o];
+        character = g_label[o];
         /* handle '\0' */
         if (g_label[o] == '\\' && g_label[o + 1] == '0') {
-          g_ind = '\0';
-          fprintf(g_file_out_ptr, "d%d ", g_ind);
+          character = '\0';
+          fprintf(g_file_out_ptr, "d%d ", character);
           o++;
         }
         /* handle '\x' */
@@ -3264,8 +3266,8 @@ int directive_asc(void) {
             print_error(g_error_message, ERROR_INP);
             return FAILED;
           }
-          g_ind = tmp_c;
-          fprintf(g_file_out_ptr, "d%d ", g_ind);
+          character = tmp_c;
+          fprintf(g_file_out_ptr, "d%d ", character);
         }
         else {
           int tmp_a = 0;
@@ -3279,7 +3281,7 @@ int directive_asc(void) {
               return FAILED;
             }
             tmp_a = 0x80;
-            g_ind = g_label[o];
+            character = g_label[o];
           }
           /* handle '\>' */
           else if (g_label[o] == '\\' && g_label[o + 1] == '>' && o == 0) {
@@ -3293,13 +3295,13 @@ int directive_asc(void) {
           }
           /* handle '\\' */
           else if (g_label[o] == '\\' && g_label[o + 1] == '\\') {
-            g_ind = '\\';
+            character = '\\';
             o++;
           }
-          if (g_ind < 0)
-            g_ind += 256;
-          g_ind = (int)g_asciitable[g_ind];
-          fprintf(g_file_out_ptr, "d%d ", g_ind|tmp_a);
+          if (character < 0)
+            character += 256;
+          character = (int)g_asciitable[character];
+          fprintf(g_file_out_ptr, "d%d ", character|tmp_a);
         }
       }
     }
@@ -3320,8 +3322,8 @@ int directive_asc(void) {
           print_error(g_error_message, ERROR_INP);
           return FAILED;
         }
-        g_ind = (int)g_asciitable[g_parsed_int];
-        fprintf(g_file_out_ptr, "d%d ", g_ind);
+        character = (int)g_asciitable[g_parsed_int];
+        fprintf(g_file_out_ptr, "d%d ", character);
       }
     }
     else {

--- a/pass_1.c
+++ b/pass_1.c
@@ -9326,11 +9326,13 @@ int parse_directive(void) {
   /* OUTNAME */
 
   if (strcaselesscmp(g_current_directive, "OUTNAME") == 0) {
+    int number_result;
+
     g_expect_calculations = NO;
-    g_inz = input_number();
+    number_result = input_number();
     g_expect_calculations = YES;
 
-    if (g_inz != INPUT_NUMBER_STRING && g_inz != INPUT_NUMBER_ADDRESS_LABEL) {
+    if (number_result != INPUT_NUMBER_STRING && number_result != INPUT_NUMBER_ADDRESS_LABEL) {
       print_error(".OUTNAME needs a file name string.\n", ERROR_DIR);
       return FAILED;
     }
@@ -9582,6 +9584,8 @@ int parse_directive(void) {
   /* LICENSEECODENEW */
 
   if (strcaselesscmp(g_current_directive, "LICENSEECODENEW") == 0) {
+    int token_result;
+
     no_library_files(".LICENSEECODENEW");
     
     if (g_licenseecodeold_defined != 0) {
@@ -9589,10 +9593,10 @@ int parse_directive(void) {
       return FAILED;
     }
 
-    if ((g_ind = get_next_token()) == FAILED)
+    if ((token_result = get_next_token()) == FAILED)
       return FAILED;
 
-    if (g_ind != GET_NEXT_TOKEN_STRING) {
+    if (token_result != GET_NEXT_TOKEN_STRING) {
       print_error(".LICENSEECODENEW requires a string of two letters.\n", ERROR_DIR);
       return FAILED;
     }
@@ -9740,10 +9744,12 @@ int parse_directive(void) {
   if (strcaselesscmp(g_current_directive, "EXPORT") == 0) {
     q = 0;
     while (1) {
-      g_ind = input_next_string();
-      if (g_ind == FAILED)
+      int string_result;
+
+      string_result = input_next_string();
+      if (string_result == FAILED)
         return FAILED;
-      if (g_ind == INPUT_NUMBER_EOL) {
+      if (string_result == INPUT_NUMBER_EOL) {
         if (q != 0) {
           next_line();
           return SUCCEEDED;
@@ -9764,8 +9770,7 @@ int parse_directive(void) {
   /* SYM/SYMBOL */
 
   if (strcaselesscmp(g_current_directive, "SYM") == 0 || strcaselesscmp(g_current_directive, "SYMBOL") == 0) {
-    g_ind = input_next_string();
-    if (g_ind != SUCCEEDED) {
+    if (input_next_string() != SUCCEEDED) {
       print_error(".SYM requires a symbol name.\n", ERROR_DIR);
       return FAILED;
     }

--- a/pass_1.c
+++ b/pass_1.c
@@ -7879,7 +7879,7 @@ int directive_endm(void) {
 
 int directive_snesheader(void) {
 
-  int q;
+  int token_result;
   
   if (g_snesheader_defined != 0) {
     print_error(".SNESHEADER can be defined only once.\n", ERROR_DIR);
@@ -7896,10 +7896,10 @@ int directive_snesheader(void) {
     return FAILED;
   }
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
-      q = parse_if_directive();
+      int q = parse_if_directive();
       if (q == FAILED)
         return FAILED;
       else if (q == SUCCEEDED)
@@ -7910,75 +7910,83 @@ int directive_snesheader(void) {
     if (strcaselesscmp(g_tmp, ".ENDSNES") == 0)
       break;
     else if (strcaselesscmp(g_tmp, "ID") == 0) {
-      if ((g_ind = get_next_token()) == FAILED)
+      if ((token_result = get_next_token()) == FAILED)
         return FAILED;
 
-      if (g_ind != GET_NEXT_TOKEN_STRING || g_tmp[4] != 0) {
+      if (token_result != GET_NEXT_TOKEN_STRING || g_tmp[4] != 0) {
         print_error("ID requires a string of 1 to 4 letters.\n", ERROR_DIR);
         return FAILED;
       }
 
       /* no ID has been defined so far */
       if (g_snesid_defined == 0) {
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_ind < 4; g_ind++)
-          g_snesid[g_ind] = g_tmp[g_ind];
+        int i;
 
-        for ( ; g_ind < 4; g_snesid[g_ind] = 0, g_ind++)
+        for (i = 0; g_tmp[i] != 0 && i < 4; i++)
+          g_snesid[i] = g_tmp[i];
+
+        for ( ; i < 4; g_snesid[i] = 0, i++)
           ;
 
         g_snesid_defined = 1;
       }
       /* compare the IDs */
       else {
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_snesid[g_ind] != 0 && g_ind < 4; g_ind++)
-          if (g_snesid[g_ind] != g_tmp[g_ind])
+        int i;
+
+        for (i = 0; g_tmp[i] != 0 && g_snesid[i] != 0 && i < 4; i++)
+          if (g_snesid[i] != g_tmp[i])
             break;
 
-        if (g_ind == 4 && g_tmp[g_ind] != 0) {
+        if (i == 4 && g_tmp[i] != 0) {
           print_error("ID requires a string of 1 to 4 letters.\n", ERROR_DIR);
           return FAILED;
         }
-        if (g_ind != 4 && (g_snesid[g_ind] != 0 || g_tmp[g_ind] != 0)) {
+        if (i != 4 && (g_snesid[i] != 0 || g_tmp[i] != 0)) {
           print_error("ID was already defined.\n", ERROR_DIR);
           return FAILED;
         }
       }
     }    
     else if (strcaselesscmp(g_tmp, "NAME") == 0) {
-      if ((g_ind = get_next_token()) == FAILED)
+      if ((token_result = get_next_token()) == FAILED)
         return FAILED;
 
-      if (g_ind != GET_NEXT_TOKEN_STRING) {
+      if (token_result != GET_NEXT_TOKEN_STRING) {
         print_error("NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
         return FAILED;
       }
 
       /* no name has been defined so far */
       if (g_name_defined == 0) {
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_ind < 21; g_ind++)
-          g_name[g_ind] = g_tmp[g_ind];
+        int i;
 
-        if (g_ind == 21 && g_tmp[g_ind] != 0) {
+        for (i = 0; g_tmp[i] != 0 && i < 21; i++)
+          g_name[i] = g_tmp[i];
+
+        if (i == 21 && g_tmp[i] != 0) {
           print_error("NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
           return FAILED;
         }
 
-        for ( ; g_ind < 21; g_name[g_ind] = 0, g_ind++)
+        for ( ; i < 21; g_name[i] = 0, i++)
           ;
 
         g_name_defined = 1;
       }
       /* compare the names */
       else {
-        for (g_ind = 0; g_tmp[g_ind] != 0 && g_name[g_ind] != 0 && g_ind < 21; g_ind++)
-          if (g_name[g_ind] != g_tmp[g_ind])
+        int i;
+
+        for (i = 0; g_tmp[i] != 0 && g_name[i] != 0 && i < 21; i++)
+          if (g_name[i] != g_tmp[i])
             break;
 
-        if (g_ind == 21 && g_tmp[g_ind] != 0) {
+        if (i == 21 && g_tmp[i] != 0) {
           print_error("NAME requires a string of 1 to 21 letters.\n", ERROR_DIR);
           return FAILED;
         }
-        if (g_ind != 21 && (g_name[g_ind] != 0 || g_tmp[g_ind] != 0)) {
+        if (i != 21 && (g_name[i] != 0 || g_tmp[i] != 0)) {
           print_error("NAME was already defined.\n", ERROR_DIR);
           return FAILED;
         }
@@ -8035,14 +8043,14 @@ int directive_snesheader(void) {
       g_fastrom_defined++;
     }
     else if (strcaselesscmp(g_tmp, "CARTRIDGETYPE") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "CARTRIDGETYPE expects 8-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_cartridgetype_defined != 0 && g_parsed_int != g_cartridgetype) {
           print_error("CARTRIDGETYPE was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -8055,37 +8063,41 @@ int directive_snesheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "ROMSIZE") == 0) {
+      int number_result;
+
       if (g_snesromsize != 0) {
         print_error("ROMSIZE can be defined only once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "ROMSIZE expects 8-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED)
+      else if (number_result == SUCCEEDED)
         g_snesromsize = g_parsed_int;
       else
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "SRAMSIZE") == 0) {
+      int number_result;
+
       if (g_sramsize_defined != 0) {
         print_error("SRAMSIZE can be defined only once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < 0 || g_parsed_int > 3)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < 0 || g_parsed_int > 3)) {
         snprintf(g_error_message, sizeof(g_error_message), "SRAMSIZE expects 0-3, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         g_sramsize = g_parsed_int;
         g_sramsize_defined++;
       }
@@ -8093,19 +8105,21 @@ int directive_snesheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "COUNTRY") == 0) {
+      int number_result;
+
       if (g_country_defined != 0) {
         print_error("COUNTRY can be defined only once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "COUNTRY expects 8-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         g_country = g_parsed_int;
         g_country_defined++;
       }
@@ -8113,19 +8127,21 @@ int directive_snesheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "LICENSEECODE") == 0) {
+      int number_result;
+
       if (g_licenseecode_defined != 0) {
         print_error("LICENSEECODE can be defined only once.\n", ERROR_DIR);
         return FAILED;
       }
 
-      g_inz = input_number();
+      number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "LICENSEECODE expects 8-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         g_licenseecode = g_parsed_int;
         g_licenseecode_defined++;
       }
@@ -8133,14 +8149,14 @@ int directive_snesheader(void) {
         return FAILED;
     }
     else if (strcaselesscmp(g_tmp, "VERSION") == 0) {
-      g_inz = input_number();
+      int number_result = input_number();
 
-      if (g_inz == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
+      if (number_result == SUCCEEDED && (g_parsed_int < -128 || g_parsed_int > 255)) {
         snprintf(g_error_message, sizeof(g_error_message), "VERSION expects 8-bit data, %d is out of range!\n", g_parsed_int);
         print_error(g_error_message, ERROR_DIR);
         return FAILED;
       }
-      else if (g_inz == SUCCEEDED) {
+      else if (number_result == SUCCEEDED) {
         if (g_version_defined != 0 && g_version != g_parsed_int) {
           print_error("VERSION was defined for the second time.\n", ERROR_DIR);
           return FAILED;
@@ -8153,12 +8169,12 @@ int directive_snesheader(void) {
         return FAILED;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break; 
     } 
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .SNESHEADER data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -3475,42 +3475,43 @@ int directive_dsl(void) {
 
 int directive_dd(void) {
 
+  int i, number_result;
   char bak[256];
 
   fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
 
   strcpy(bak, g_current_directive);
 
-  g_inz = input_number();
-  for (g_ind = 0; g_inz == SUCCEEDED || g_inz == INPUT_NUMBER_ADDRESS_LABEL || g_inz == INPUT_NUMBER_STACK; g_ind++) {
+  number_result = input_number();
+  for (i = 0; number_result == SUCCEEDED || number_result == INPUT_NUMBER_ADDRESS_LABEL || number_result == INPUT_NUMBER_STACK; i++) {
     /*
-    if (g_inz == SUCCEEDED && (g_parsed_int < -2147483648 || g_parsed_int > 2147483647)) {
+    if (number_result == SUCCEEDED && (g_parsed_int < -2147483648 || g_parsed_int > 2147483647)) {
       snprintf(g_error_message, sizeof(g_error_message), ".%s expects 32-bit data, %d is out of range!\n", bak, g_parsed_int);
       print_error(g_error_message, ERROR_DIR);
       return FAILED;
     }
     */
 
-    if (g_inz == SUCCEEDED)
+    if (number_result == SUCCEEDED)
       fprintf(g_file_out_ptr, "u%d ", g_parsed_int);
-    else if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+    else if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
       fprintf(g_file_out_ptr, "V%s ", g_label);
-    else if (g_inz == INPUT_NUMBER_STACK)
+    else if (number_result == INPUT_NUMBER_STACK)
       fprintf(g_file_out_ptr, "U%d ", g_latest_stack);
     
-    g_inz = input_number();
+    number_result = input_number();
   }
 
-  if (g_inz == FAILED)
+  if (number_result == FAILED)
     return FAILED;
 
-  if ((g_inz == INPUT_NUMBER_EOL || g_inz == INPUT_NUMBER_STRING) && g_ind == 0) {
+  if ((number_result == INPUT_NUMBER_EOL || number_result == INPUT_NUMBER_STRING) && i == 0) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", bak);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
   }
 
-  if (g_inz == INPUT_NUMBER_EOL)
+  if (number_result == INPUT_NUMBER_EOL)
     next_line();
 
   return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -7234,7 +7234,7 @@ int directive_redefine_redef(void) {
 
 int directive_smsheader(void) {
   
-  int q;
+  int q, token_result;
     
   if (g_smsheader_defined != 0) {
     print_error(".SMSHEADER can be defined only once.\n", ERROR_DIR);
@@ -7252,7 +7252,7 @@ int directive_smsheader(void) {
     return FAILED;
   }
 
-  while ((g_ind = get_next_token()) == SUCCEEDED) {
+  while ((token_result = get_next_token()) == SUCCEEDED) {
     /* .IF directive? */
     if (g_tmp[0] == '.') {
       q = parse_if_directive();
@@ -7388,12 +7388,12 @@ int directive_smsheader(void) {
       g_smsreservedspace2 = g_parsed_int & 255;
     }
     else {
-      g_ind = FAILED;
+      token_result = FAILED;
       break;
     }
   }
 
-  if (g_ind != SUCCEEDED) {
+  if (token_result != SUCCEEDED) {
     print_error("Error in .SMSHEADER data structure.\n", ERROR_DIR);
     return FAILED;
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -3637,7 +3637,7 @@ int parse_dstruct_entry(char *iname, struct structure *s, int *labels_only) {
 
   /* read the data */
   it = s->items;
-  for (g_ind = 0; it != NULL; g_ind++) {
+  while (it != NULL) {
     snprintf(tmpname, sizeof(tmpname), "%s.%s", iname, it->name);
     if (verify_name_length(tmpname) == FAILED)
       return FAILED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -3425,7 +3425,7 @@ int directive_dl_long_faraddr(void) {
 
 int directive_dsl(void) {
 
-  int q;
+  int q, parsed_int;
   
   q = input_number();
   if (q == FAILED)
@@ -3441,7 +3441,7 @@ int directive_dsl(void) {
     return FAILED;
   }
 
-  g_inz = g_parsed_int;
+  parsed_int = g_parsed_int;
 
   q = input_number();
   if (q == FAILED)
@@ -3458,14 +3458,14 @@ int directive_dsl(void) {
   }
 
   if (q == SUCCEEDED)
-    fprintf(g_file_out_ptr, "h%d %d ", g_inz, g_parsed_int);
+    fprintf(g_file_out_ptr, "h%d %d ", parsed_int, g_parsed_int);
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     fprintf(g_file_out_ptr, "k%d ", g_active_file_info_last->line_current);
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "q%s ", g_label);
   }
   else if (q == INPUT_NUMBER_STACK) {
-    for (q = 0; q < g_inz; q++)
+    for (q = 0; q < parsed_int; q++)
       fprintf(g_file_out_ptr, "T%d ", g_latest_stack);
   }
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -6985,10 +6985,11 @@ int directive_undef_undefine(void) {
 
   q = 0;
   while (1) {
-    g_ind = input_next_string();
-    if (g_ind == FAILED)
+    int string_result = input_next_string();
+
+    if (string_result == FAILED)
       return FAILED;
-    if (g_ind == INPUT_NUMBER_EOL) {
+    if (string_result == INPUT_NUMBER_EOL) {
       if (q != 0) {
         next_line();
         return SUCCEEDED;

--- a/pass_1.c
+++ b/pass_1.c
@@ -334,7 +334,7 @@ int macro_start(struct macro_static *m, struct macro_runtime *mrt, int caller, i
 int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
 
   struct macro_runtime *mrt;
-  int start;
+  int start, number_result;
   
   /* start running a macro... run until .ENDM */
   if (macro_stack_grow() == FAILED)
@@ -345,11 +345,11 @@ int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
   start = g_source_pointer;
 
   if (first == NO && mrt->string_current < mrt->string_last) {
-    g_inz = SUCCEEDED;
+    number_result = SUCCEEDED;
     g_parsed_int = mrt->string[mrt->string_current++];
   }
   else {
-    g_inz = input_number();
+    number_result = input_number();
     mrt->string_current = 0;
     mrt->string_last = 0;
   }
@@ -359,7 +359,7 @@ int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
   else
     mrt->offset++;
 
-  if (g_inz == INPUT_NUMBER_EOL && first == NO) {
+  if (number_result == INPUT_NUMBER_EOL && first == NO) {
     next_line();
     return SUCCEEDED;
   }
@@ -377,11 +377,11 @@ int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
 
   /* filter all the data through that macro */
   mrt->argument_data[0]->start = start;
-  mrt->argument_data[0]->type = g_inz;
+  mrt->argument_data[0]->type = number_result;
 
-  if (g_inz == FAILED)
+  if (number_result == FAILED)
     return FAILED;
-  else if (g_inz == INPUT_NUMBER_EOL) {
+  else if (number_result == INPUT_NUMBER_EOL) {
     snprintf(g_error_message, sizeof(g_error_message), ".%s needs data.\n", name);
     print_error(g_error_message, ERROR_INP);
     return FAILED;
@@ -389,9 +389,9 @@ int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
 
   mrt->supplied_arguments = 2;
 
-  if (g_inz == INPUT_NUMBER_ADDRESS_LABEL)
+  if (number_result == INPUT_NUMBER_ADDRESS_LABEL)
     strcpy(mrt->argument_data[0]->string, g_label);
-  else if (g_inz == INPUT_NUMBER_STRING) {
+  else if (number_result == INPUT_NUMBER_STRING) {
     mrt->argument_data[0]->type = SUCCEEDED;
     mrt->argument_data[0]->value = g_label[0];
     strcpy(mrt->string, g_label);
@@ -401,9 +401,9 @@ int macro_start_dxm(struct macro_static *m, int caller, char *name, int first) {
       fprintf(stderr, "got string %s!\n", label);
     */
   }
-  else if (g_inz == INPUT_NUMBER_STACK)
+  else if (number_result == INPUT_NUMBER_STACK)
     mrt->argument_data[0]->value = (double)g_latest_stack;
-  else if (g_inz == SUCCEEDED)
+  else if (number_result == SUCCEEDED)
     mrt->argument_data[0]->value = g_parsed_int;
   else
     return FAILED;


### PR DESCRIPTION
Turn `g_ind` and `g_inz` references in pass_1.c into local variables where possible.
I also moved a few variables to inner scopes when I had the chance, but this is not the focus of this PR.

The globals were kept on the following functions as they may rely on global state.
- `parse_push_pull_registers`
- `parse_exg_tfr_registers`
- `parse_tiny_int`
- `evaluate_token`
- `parse_dstruct_entry`
- `directive_dstruct`

Although being simple, the changes are quite extensive, and I think its better if we review each commit individually.

## Stats
References to `g_ind` and `g_inz` in pass_1.c:
**Before**: 470 references.
**After**: 44 references.