### PR TITLE
Fixes for building under MSVC

### DIFF
--- a/byte_tester/main.c
+++ b/byte_tester/main.c
@@ -202,7 +202,7 @@ int extract_comments(char *input, size_t size) {
 
     /* Overwrite input string with comment contents */
     current = comment;
-    comment_length = end - current;
+    comment_length = (int)(end - current);
 
     memmove(output, current, comment_length);
     output += comment_length;

--- a/printf.c
+++ b/printf.c
@@ -32,7 +32,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 */
 
-#if defined(AMIGA) || defined(MSDOS)
+#if defined(AMIGA) || (defined(MSDOS) && !defined(WIN32))
 typedef unsigned long uintptr_t;
 typedef long intmax_t;
 #define PRINTF_DISABLE_SUPPORT_LONG_LONG 1

--- a/stack.c
+++ b/stack.c
@@ -1002,7 +1002,7 @@ int stack_calculate(char *in, int *value) {
           }
         }
         else {
-          int priority = _get_op_priority(si[k].value);
+          int priority = _get_op_priority((int)(si[k].value));
 
           b--;
           while (b != -1 && op[b] != SI_OP_LEFT && _get_op_priority(op[b]) >= priority) {


### PR DESCRIPTION
- printf.c: change for MSDOS needs to exclude WIN32
- stack.c: explicit cast double to int
- byte_tester/main.c: explicit cast ptr_diff_t to int