### PR TITLE
MSVC build fixes (again)

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1553,7 +1553,7 @@ int process_string_for_special_characters(char *label, int *string_size) {
   int size, read, write;
 
   if (string_size == NULL)
-    size = strlen(label);
+    size = (int)strlen(label);
   else
     size = *string_size;
   


### PR DESCRIPTION
Ninja build seems to default to a higher warnings-as-errors level. This explicit cast makes it happy.