### PR TITLE
clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,26 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AllowShortIfStatementsOnASingleLine: false
+BraceWrapping: 
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+  AfterFunction: false
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Custom
+ColumnLimit: 209
+ContinuationIndentWidth: 2
+IndentCaseBlocks: true
+...


### PR DESCRIPTION
Not a great deal of thought here but adding this allows clang-format to tidy the code, and for my use case, allows Resharper C++ to autoformat things to match WLA DX's slightly unusual style.