### PR TITLE
byte_tester tests have the built rom as a dependency

### DIFF
--- a/tests/6502/amiga_test/makefile
+++ b/tests/6502/amiga_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/array_test/makefile
+++ b/tests/6502/array_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/bits_test/makefile
+++ b/tests/6502/bits_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/compiler_test/makefile
+++ b/tests/6502/compiler_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/div_16bit/makefile
+++ b/tests/6502/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/functions_test/makefile
+++ b/tests/6502/functions_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/labels_test/makefile
+++ b/tests/6502/labels_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/precedence_and_if_test/makefile
+++ b/tests/6502/precedence_and_if_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6502/struct_test/makefile
+++ b/tests/6502/struct_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6510/div_16bit/makefile
+++ b/tests/6510/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/65816/div_16bit/makefile
+++ b/tests/65816/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/65c02/div_16bit/makefile
+++ b/tests/65c02/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/65ce02/div_16bit/makefile
+++ b/tests/65ce02/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6800/div_16bit/makefile
+++ b/tests/6800/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6801/div_16bit/makefile
+++ b/tests/6801/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/6809/div_16bit/makefile
+++ b/tests/6809/div_16bit/makefile
@@ -15,7 +15,7 @@ linked.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/gb-z80/delta_test/makefile
+++ b/tests/gb-z80/delta_test/makefile
@@ -16,7 +16,7 @@ linked.gb: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: linked.gb
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/spc-700/mnemonics_test/makefile
+++ b/tests/spc-700/mnemonics_test/makefile
@@ -16,7 +16,7 @@ result.rom: $(OFILES) makefile
 main.o: main.s
 	$(CC) $(CFLAGS) main.o main.s
 
-check:
+check: result.rom
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/linker_test_1/makefile
+++ b/tests/z80/linker_test_1/makefile
@@ -19,7 +19,7 @@ main.o: main.s defines.i
 setup.o: setup.s defines.i
 	$(CC) $(CFLAGS) setup.o setup.s
 
-check:
+check: linked.prg
 	byte_tester -s main.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/mnemonics_test/makefile
+++ b/tests/z80/mnemonics_test/makefile
@@ -13,7 +13,7 @@ all: result.rom check
 result.rom: $(OFILES) makefile
 	$(LD) $(LDFLAGS) linkfile result.rom
 
-check:
+check: result.rom
 	byte_tester -s main.s
 
 main.o: main.s

--- a/tests/z80/ram_sections/makefile
+++ b/tests/z80/ram_sections/makefile
@@ -19,7 +19,7 @@ sms.o: sms.s
 library.lib: library.s
 	$(CC) -l library.lib library.s
 
-check:
+check: linked.rom
 	byte_tester -s sms.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/rst_test/makefile
+++ b/tests/z80/rst_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 sms.o: sms.s
 	$(CC) $(CFLAGS) sms.o sms.s
 
-check:
+check: linked.rom
 	byte_tester -s sms.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/sms_test/makefile
+++ b/tests/z80/sms_test/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 sms.o: sms.s
 	$(CC) $(CFLAGS) sms.o sms.s
 
-check:
+check: linked.rom
 	byte_tester -s sms.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/smschecksum_test_1/makefile
+++ b/tests/z80/smschecksum_test_1/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 sms.o: sms.s
 	$(CC) $(CFLAGS) sms.o sms.s
 
-check:
+check: linked.rom
 	byte_tester -s sms.s
 
 $(OFILES): $(HFILES)

--- a/tests/z80/smschecksum_test_2/makefile
+++ b/tests/z80/smschecksum_test_2/makefile
@@ -16,7 +16,7 @@ linked.rom: $(OFILES) makefile
 sms.o: sms.s
 	$(CC) $(CFLAGS) sms.o sms.s
 
-check:
+check: linked.rom
 	byte_tester -s sms.s
 
 $(OFILES): $(HFILES)


### PR DESCRIPTION
This fixes ./run_tests.sh when make is run with multiple threads (ie. when MAKEFLAGS="-j4" is an environment variable). When multiple threads are used then it would attempt to do the check before the ROM has actually compiled because it tries to both built the ROM and do the test in parallel.