### PR TITLE
Change to dynamically-allocated memory for .stringmaptable strings

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -762,7 +762,7 @@ struct stringmap_entry {
 };
 
 struct stringmaptable {
-  char name[MAX_NAME_LENGTH + 1];
+  char *name;
   char *filename;
   struct stringmap_entry *entries;
   struct stringmaptable *next;

--- a/main.c
+++ b/main.c
@@ -699,6 +699,7 @@ void procedures_at_exit(void) {
       free(e);
     }
     free(sm->filename);
+    free(sm->name);
     g_stringmaptables = sm->next;
     free(sm);
   }

--- a/pass_1.c
+++ b/pass_1.c
@@ -9113,7 +9113,12 @@ int directive_stringmap_table(void) {
   map->next = g_stringmaptables;
   g_stringmaptables = map;
 
-  strcpy(map->name, g_label);
+  map->name = string_duplicate(g_label);
+  if (map->name == NULL) {
+    snprintf(g_error_message, sizeof(g_error_message), "Out of memory while trying allocate info structure for file \"%s\".\n", g_full_name);
+    print_error(g_error_message, ERROR_DIR);
+    return FAILED;
+  }
 
   g_expect_calculations = NO;
   parse_result = input_number();
@@ -9128,12 +9133,11 @@ int directive_stringmap_table(void) {
   create_full_name(g_include_dir, g_label);
   localize_path(g_label);
 
-  map->filename = calloc(strlen(g_label) + 1, 1);
+  map->filename = string_duplicate(g_label);
   if (map->filename == NULL) {
     print_error(ERROR_DIR, "Out of memory while trying allocate info structure for file \"%s\".\n", g_full_name);
     return FAILED;
   }
-  strcpy(map->filename, g_label);
 
   table_file = fopen(g_label, "r");
   if (table_file == NULL) {

--- a/pass_1.c
+++ b/pass_1.c
@@ -9100,7 +9100,7 @@ int directive_stringmap_table(void) {
   g_expect_calculations = YES;
 
   if (parse_result != INPUT_NUMBER_STRING && parse_result != INPUT_NUMBER_ADDRESS_LABEL) {
-    print_error(ERROR_DIR, ".STRINGMAPTABLE needs a file name string.\n");
+    print_error(ERROR_DIR, ".STRINGMAPTABLE needs a name string.\n");
     return FAILED;
   }
 
@@ -9115,8 +9115,7 @@ int directive_stringmap_table(void) {
 
   map->name = string_duplicate(g_label);
   if (map->name == NULL) {
-    snprintf(g_error_message, sizeof(g_error_message), "Out of memory while trying allocate info structure for file \"%s\".\n", g_full_name);
-    print_error(g_error_message, ERROR_DIR);
+    print_error(ERROR_ERR, "STRINGMAPTABLE: Out of memory error.\n");
     return FAILED;
   }
 
@@ -9135,7 +9134,7 @@ int directive_stringmap_table(void) {
 
   map->filename = string_duplicate(g_label);
   if (map->filename == NULL) {
-    print_error(ERROR_DIR, "Out of memory while trying allocate info structure for file \"%s\".\n", g_full_name);
+    print_error(ERROR_ERR, "STRINGMAPTABLE: Out of memory error.\n");
     return FAILED;
   }
 


### PR DESCRIPTION
As discussed at https://github.com/vhelin/wla-dx/discussions/472, here's a first step to not using MAX_NAME_LENGTH.