### PR TITLE
Change MAX_NAME_LENGTH logic to give the higher limit in Windows

### DIFF
--- a/shared.h
+++ b/shared.h
@@ -3,7 +3,7 @@
 #define _SHARED_H
 
 /* want to use longer strings and labels? change this - PS. it doesn't contain the null terminator */
-#if defined(AMIGA) || defined(MSDOS)
+#if defined(AMIGA) || (defined(MSDOS) && !defined(WIN32))
 #define MAX_NAME_LENGTH 511
 #else
 #define MAX_NAME_LENGTH 2047


### PR DESCRIPTION
We need a little extra logic to enable longer strings in Windows, as for some reason it also defines MSDOS.