### PR TITLE
Change SDSC tag strings to heap copies

### DIFF
--- a/main.c
+++ b/main.c
@@ -90,7 +90,9 @@ char *g_final_name = NULL, *g_asm_name = NULL;
 struct ext_include_collection g_ext_incdirs;
 struct structure **g_saved_structures2 = NULL;
 
-
+#ifdef Z80
+extern char *g_sdsctag_name_str, *g_sdsctag_notes_str, *g_sdsctag_author_str;
+#endif
 
 static int _allocate_global_buffers(void) {
 
@@ -719,6 +721,12 @@ void procedures_at_exit(void) {
   stack_calculate_free_allocations();
   
   _free_global_buffers();
+
+#ifdef Z80
+  free(g_sdsctag_name_str);
+  free(g_sdsctag_notes_str);
+  free(g_sdsctag_author_str);
+#endif
 }
 
 

--- a/pass_1.c
+++ b/pass_1.c
@@ -34,7 +34,7 @@ int g_version = 0, g_version_defined = 0;
 #endif
 
 #ifdef Z80
-char *g_sdsctag_name_str, *g_sdsctag_notes_str, *g_sdsctag_author_str;
+char *g_sdsctag_name_str = NULL, *g_sdsctag_notes_str = NULL, *g_sdsctag_author_str = NULL;
 int g_sdsctag_name_type, g_sdsctag_notes_type, g_sdsctag_author_type, g_sdsc_ma, g_sdsc_mi;
 int g_sdsctag_name_value, g_sdsctag_notes_value, g_sdsctag_author_value;
 int g_computesmschecksum_defined = 0, g_sdsctag_defined = 0, g_smstag_defined = 0;

--- a/pass_1.c
+++ b/pass_1.c
@@ -34,7 +34,7 @@ int g_version = 0, g_version_defined = 0;
 #endif
 
 #ifdef Z80
-char g_sdsctag_name_str[MAX_NAME_LENGTH + 1], g_sdsctag_notes_str[MAX_NAME_LENGTH + 1], g_sdsctag_author_str[MAX_NAME_LENGTH + 1];
+char *g_sdsctag_name_str, *g_sdsctag_notes_str, *g_sdsctag_author_str;
 int g_sdsctag_name_type, g_sdsctag_notes_type, g_sdsctag_author_type, g_sdsc_ma, g_sdsc_mi;
 int g_sdsctag_name_value, g_sdsctag_notes_value, g_sdsctag_author_value;
 int g_computesmschecksum_defined = 0, g_sdsctag_defined = 0, g_smstag_defined = 0;
@@ -7624,12 +7624,12 @@ int directive_sdsctag(void) {
     }
     else {
       g_sdsctag_name_type = TYPE_STRING;
-      strcpy(g_sdsctag_name_str, g_label);
+      g_sdsctag_name_str = string_duplicate(g_label);
     }
   }
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     g_sdsctag_name_type = TYPE_LABEL;
-    strcpy(g_sdsctag_name_str, g_label);
+    g_sdsctag_name_str = string_duplicate(g_label);
   }
   else {
     g_sdsctag_name_type = TYPE_STACK_CALCULATION;
@@ -7656,12 +7656,12 @@ int directive_sdsctag(void) {
     }
     else {
       g_sdsctag_notes_type = TYPE_STRING;
-      strcpy(g_sdsctag_notes_str, g_label);
+      g_sdsctag_notes_str = string_duplicate(g_label);
     }
   }
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     g_sdsctag_notes_type = TYPE_LABEL;
-    strcpy(g_sdsctag_notes_str, g_label);
+    g_sdsctag_notes_str = string_duplicate(g_label);
   }
   else {
     g_sdsctag_notes_type = TYPE_STACK_CALCULATION;
@@ -7688,12 +7688,12 @@ int directive_sdsctag(void) {
     }
     else {
       g_sdsctag_author_type = TYPE_STRING;
-      strcpy(g_sdsctag_author_str, g_label);
+      g_sdsctag_author_str = string_duplicate(g_label);
     }
   }
   else if (q == INPUT_NUMBER_ADDRESS_LABEL) {
     g_sdsctag_author_type = TYPE_LABEL;
-    strcpy(g_sdsctag_author_str, g_label);
+    g_sdsctag_author_str = string_duplicate(g_label);
   }
   else {
     g_sdsctag_author_type = TYPE_STACK_CALCULATION;

--- a/pass_2.c
+++ b/pass_2.c
@@ -32,7 +32,7 @@ unsigned char g_nintendo_logo_dat[] = {
 #endif
 
 #ifdef Z80
-extern char g_sdsctag_name_str[MAX_NAME_LENGTH + 1], g_sdsctag_notes_str[MAX_NAME_LENGTH + 1], g_sdsctag_author_str[MAX_NAME_LENGTH + 1];
+extern char *g_sdsctag_name_str, *g_sdsctag_notes_str, *g_sdsctag_author_str;
 extern int g_sdsctag_name_type, g_sdsctag_notes_type, g_sdsctag_author_type, g_sdsc_ma, g_sdsc_mi;
 extern int g_sdsctag_name_value, g_sdsctag_notes_value, g_sdsctag_author_value;
 extern int g_computesmschecksum_defined, g_sdsctag_defined, g_smstag_defined;


### PR DESCRIPTION
This is a bit uglier as the buffers are hidden behind a #define. I wonder if we might instead add these sorts of "loose buffers" to a global set to make it easier to clean them up at the end? (Or, of course, just leak them..?)