### PR TITLE
UTF-8 support for labels without : and definition names

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1363,7 +1363,7 @@ int get_next_plain_string(void) {
       g_ss++;
       g_source_pointer++;
     }
-    else if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.' || c == '{' || c == '}' || c == '\\' || c == '@' || c == ':') {
+    else if ((unsigned char)c > 127 || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.' || c == '{' || c == '}' || c == '\\' || c == '@' || c == ':') {
       g_label[g_ss] = c;
       g_ss++;
       g_source_pointer++;

--- a/pass_1.c
+++ b/pass_1.c
@@ -1165,7 +1165,7 @@ int evaluate_token(void) {
 
   /* OPCODE? */
   {
-    int op_id = g_tmp[0];
+    int op_id = (unsigned char)g_tmp[0];
 
     if (op_id < 0) {
       print_error(ERROR_LOG, "Invalid value\n");
@@ -1177,7 +1177,7 @@ int evaluate_token(void) {
 
   g_opt_tmp = &g_opcodes_table[g_ind];
 
-  for (f = g_opcode_n[(unsigned int)g_tmp[0]]; f > 0; f--) {
+  for (f = g_opcode_n[(unsigned char)g_tmp[0]]; f > 0; f--) {
 #if W65816
     if (g_use_wdc_standard == 0) {
       /* skip all mnemonics that contain '<', '|' and '>' */


### PR DESCRIPTION
Cast opcode chars to unsigned to enable correct handling of labels starting with extended characters with no colon

Relates to #29