### PR TITLE
Fixed warning

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -72,7 +72,7 @@ unsigned int hashmap_hash_int(hashmap_map * m, char* keystring) {
   key ^= (key >> 12);
 
   /* Knuth's Multiplicative Method */
-  key = (key >> 3) * 2654435761;
+  key = (key >> 3) * 2654435761U;
 
   return key % m->table_size;
 }


### PR DESCRIPTION
```
/RAM/wla_dx_v10.2/hashmap.c: In function 'hashmap_hash_int':
/RAM/wla_dx_v10.2/hashmap.c:75:3: warning: this decimal constant is unsigned onl
y in ISO C90
   75 |   key = (key >> 3) * 2654435761;
      |   ^~~