### PR TITLE
exclude auto-generated makefile from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ wla_[ab].tmp
 
 # Generated files
 ins_tbl_gen/t*.c
+byte_tester/makefile
 
 # CMake files
 /*[Bb]uild*/


### PR DESCRIPTION
This makefile shouldn't be under version control because it is auto-generated.