### PR TITLE
full expanded name of assembler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-WLA DX
+Wzonka-Lad Assembler Deluxe
 ======
 
 WLA DX - Yet Another


### PR DESCRIPTION
"Wzonka-Lad" is one syllable shorter than "WLA" so I think the assembler will be easier for people to talk about if the full expanded name is put in a more obvious spot.