### PR TITLE
Improved makefile dependency rules generation to support deleted include files

### DIFF
--- a/include.c
+++ b/include.c
@@ -511,11 +511,10 @@ char *get_file_name(int id) {
 
 
 /* converts filename to forward slashes for make compatibility */
-void print_file_name(FILE *f, char *prefix, char *file_name) {
+void print_file_name(FILE *f, char *file_name) {
 
   char c;
   
-  fprintf(f, "%s", prefix);
   for (c = *file_name++; c != 0; c = *file_name++) {
     if (c == '\\')
       fputc('/', f);
@@ -524,14 +523,25 @@ void print_file_name(FILE *f, char *prefix, char *file_name) {
   }
 }
 
+void print_makefile_rule(FILE *f, char *target_file_name, char *prerequisite_file_name) {
 
-int print_file_names(void) {
+  print_file_name(f, target_file_name);
+  fputc(':', f);
+  fputc(' ', f);
+  print_file_name(f, prerequisite_file_name);
+  fputc('\n', f);
+
+  print_file_name(f, prerequisite_file_name);
+  fputc(':', f);
+  fputc('\n', f);
+}
+
+int print_file_names(char *target_file_name) {
 
   struct incbin_file_data *ifd;
   struct file_name_info *fni;
   struct stringmaptable *smt;
   struct string *fopens;
-  int is_first_line = YES;
   
   fni = g_file_name_info_first;
   ifd = g_incbin_file_data_first;
@@ -541,30 +551,25 @@ int print_file_names(void) {
   /* included files */
   /* handle the main file name differently */
   while (fni != NULL) {
-    if (is_first_line == YES) {
-      print_file_name(stdout, "", fni->name);
-      is_first_line = NO;
-    }
-    else
-      print_file_name(stdout, " \\\n\t", fni->name);
+    print_makefile_rule(stdout, target_file_name, fni->name);
     fni = fni->next;
   }
 
   /* incbin files */
   while (ifd != NULL) {
-    print_file_name(stdout, " \\\n\t", ifd->name);
+    print_makefile_rule(stdout, target_file_name, ifd->name);
     ifd = ifd->next;
   }
 
   /* stringmaptable files */
   while (smt != NULL) {
-    print_file_name(stdout, " \\\n\t", smt->filename);
+    print_makefile_rule(stdout, target_file_name, smt->filename);
     smt = smt->next;
   }
 
   /* filenames used in .fopens */
   while (fopens != NULL) {
-    print_file_name(stdout, " \\\n\t", fopens->string);
+    print_makefile_rule(stdout, target_file_name, fopens->string);
     fopens = fopens->next;
   }
 

--- a/include.h
+++ b/include.h
@@ -6,7 +6,7 @@ int include_file(char *name, int *include_size, char *namespace);
 int incbin_file(char *name, int *id, int *swap, int *skip, int *read, struct macro_static **macro);
 int preprocess_file(char *c, char *d, char *o, int *s, char *f);
 int create_full_name(char *dir, char *name);
-int print_file_names(void);
+int print_file_names(char *target_file_name);
 char *get_file_name(int id);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -72,7 +72,7 @@ extern int g_include_in_tmp_size, g_tmp_a_size, *g_banks, *g_bankaddress;
 extern int g_saved_structures_count, g_sizeof_g_tmp, g_global_listfile_items, *g_global_listfile_ints;
 
 int g_output_format = OUTPUT_NONE, g_verbose_level = 0, g_test_mode = OFF;
-int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO;
+int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO, g_makefile_add_phony_targets = NO;
 int g_listfile_data = NO, g_quiet = NO, g_use_incdir = NO, g_little_endian = YES;
 int g_create_sizeof_definitions = YES, g_global_label_hint = HINT_NONE, g_keep_empty_sections = NO;
 int g_can_calculate_a_minus_b = YES, g_is_file_isolated_counter = 0;
@@ -223,6 +223,7 @@ int main(int argc, char *argv[]) {
     printf("-i  Add list file information\n");
     printf("-k  Keep empty sections\n");
     printf("-M  Output makefile rules\n");
+    printf("-MP Create phony a target for each dependency other than the main file\n");
     printf("-q  Quiet\n");
     printf("-s  Don't create _sizeof_* and _paddingof_* definitions\n");
     printf("-t  Test assemble\n");
@@ -417,6 +418,10 @@ int parse_flags(char **flags, int flagc, int *print_usage) {
       g_test_mode = ON;
       g_verbose_level = 0;
       g_quiet = YES;
+      continue;
+    }
+    else if (!strcmp(flags[count], "-MP")) {
+      g_makefile_add_phony_targets = YES;
       continue;
     }
     else if (!strcmp(flags[count], "-q")) {

--- a/phase_4.c
+++ b/phase_4.c
@@ -1927,8 +1927,7 @@ int phase_4(void) {
 
   /* output makefile rules */
   if (g_makefile_rules == YES) {
-    fprintf(stdout, "%s: ", g_final_name);
-    print_file_names();
+    print_file_names(g_final_name);
   }
 
   /* show project information */


### PR DESCRIPTION
Option -M generates makefile dependency rules. However, those rules break when an include file is deleted.

For example, assuming a file `main.asm` includes two other files `h1.inc` and `h2.inc`, the following makefile dependency rule would be generated.

```
main.asm: h1.inc \
  h2.inc
```

This works fine as long as the headers are there. However, if `h1.inc` is deleted (and the include statement removed from `main.asm`), `make` will fail, because `h1.inc` will still be referenced by the dependency rule, but there are no rule to produce `h1.inc`. The same issue would happen if `h2.inc` were to be deleted.

To solve the issue, the dependency rules are generated as follows.

```
main.asm: h1.inc
h1.inc:
main.asm: h2.inc
h2.inc:
```

Adding empty rules for each header prevents `make` from failing, and once compilation is over, any reference to the deleted include files will be gone.