### PR TITLE
Added option -MF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,13 +3,15 @@
 1... WLA GB-Z80/Z80/6502/65C02/65CE02/65816/68000/6800/6801/6809/8008/8080/HUC6280/SPC-700/SuperFX History
 ----------------------------------------------------------------------------------------------------------
 
-v10.6 (29-Jun-2023) [ALL] Conditions (e.g., "(A > 1 || B < 3)") can now be used
+v10.6 (30-Jun-2023) [ALL] Conditions (e.g., "(A > 1 || B < 3)") can now be used
                       everywhere, outside .IFs.
                     [ALL] It's not any more possible to create labels and
                       definitions called "_b" and "_f" as they are reserved names.
                     [ALL] A definition and a label cannot any more share the same
                       name inside a source file for the sake of clarity.
                     [ALL] Added -MP for generating phony targets with -M.
+                    [ALL] Added -MF for specifying a file to write the
+					  dependencies to with -M.
 
 v10.5 (23-Jun-2023) [ALL] .DSB, .DSW, .DSL and .DSD produced only one pending
                       calculation struct when encountered a pending calculation

--- a/doc/wlaflags.rst
+++ b/doc/wlaflags.rst
@@ -16,6 +16,7 @@ You can supply WLA with some (or all or none) of the following option flags.
     source file.
 -MP Create a phony target for each dependency other than the main file,
     use this with -M.
+-MF Specify a file to write the dependencies to, use this with -M.
 -q  Quiet mode. ``.PRINT*`` -directives output nothing.
 -s  Don't create _sizeof_* and _padding_* definitions.
 -t  Test assemble. Doesn't output any files.

--- a/include.c
+++ b/include.c
@@ -16,6 +16,7 @@
 
 
 extern int g_source_index, g_extra_definitions, g_parsed_int, g_use_incdir, g_makefile_rules, g_makefile_add_phony_targets;
+extern FILE* g_makefile_rule_file;
 extern char *g_tmp, g_label[MAX_NAME_LENGTH + 1];
 extern struct ext_include_collection g_ext_incdirs;
 extern FILE *g_file_out_ptr;
@@ -555,30 +556,30 @@ int print_file_names(char *target_file_name) {
   /* handle the main file name differently */
   while (fni != NULL) {
     if (is_first_line == YES) {
-      print_makefile_rule(stdout, target_file_name, fni->name, NO);
+      print_makefile_rule(g_makefile_rule_file, target_file_name, fni->name, NO);
       is_first_line = NO;
     }
     else {
-      print_makefile_rule(stdout, target_file_name, fni->name, g_makefile_add_phony_targets);
+      print_makefile_rule(g_makefile_rule_file, target_file_name, fni->name, g_makefile_add_phony_targets);
     }
     fni = fni->next;
   }
 
   /* incbin files */
   while (ifd != NULL) {
-    print_makefile_rule(stdout, target_file_name, ifd->name, g_makefile_add_phony_targets);
+    print_makefile_rule(g_makefile_rule_file, target_file_name, ifd->name, g_makefile_add_phony_targets);
     ifd = ifd->next;
   }
 
   /* stringmaptable files */
   while (smt != NULL) {
-    print_makefile_rule(stdout, target_file_name, smt->filename, g_makefile_add_phony_targets);
+    print_makefile_rule(g_makefile_rule_file, target_file_name, smt->filename, g_makefile_add_phony_targets);
     smt = smt->next;
   }
 
   /* filenames used in .fopens */
   while (fopens != NULL) {
-    print_makefile_rule(stdout, target_file_name, fopens->string, g_makefile_add_phony_targets);
+    print_makefile_rule(g_makefile_rule_file, target_file_name, fopens->string, g_makefile_add_phony_targets);
     fopens = fopens->next;
   }
 

--- a/main.c
+++ b/main.c
@@ -73,6 +73,7 @@ extern int g_saved_structures_count, g_sizeof_g_tmp, g_global_listfile_items, *g
 
 int g_output_format = OUTPUT_NONE, g_verbose_level = 0, g_test_mode = OFF;
 int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO, g_makefile_add_phony_targets = NO;
+FILE *g_makefile_rule_file = NULL;
 int g_listfile_data = NO, g_quiet = NO, g_use_incdir = NO, g_little_endian = YES;
 int g_create_sizeof_definitions = YES, g_global_label_hint = HINT_NONE, g_keep_empty_sections = NO;
 int g_can_calculate_a_minus_b = YES, g_is_file_isolated_counter = 0;
@@ -156,7 +157,10 @@ int main(int argc, char *argv[]) {
     if (g_label_stack[q] == NULL)
       return 1;
   }
-  
+
+  /* default to output makefile rules to the standard output */
+  g_makefile_rule_file = stdout;
+
   parse_flags_result = FAILED;
   if (argc >= 2) {
     parse_flags_result = parse_flags(argv, argc, &print_usage);
@@ -225,6 +229,7 @@ int main(int argc, char *argv[]) {
     printf("-M  Output makefile rules\n");
     printf("-MP Create a phony target for each dependency other than the main file,\n");
     printf("    use this with -M\n");
+    printf("-MF <FILE> Specify a file to write the dependencies to, use with -M\n");
     printf("-q  Quiet\n");
     printf("-s  Don't create _sizeof_* and _paddingof_* definitions\n");
     printf("-t  Test assemble\n");
@@ -423,6 +428,18 @@ int parse_flags(char **flags, int flagc, int *print_usage) {
     }
     else if (!strcmp(flags[count], "-MP")) {
       g_makefile_add_phony_targets = YES;
+      continue;
+    }
+    else if (!strcmp(flags[count], "-MF")) {
+      if (count + 1 < flagc) {
+        g_makefile_rule_file = fopen(flags[count+1], "w");
+        if (g_makefile_rule_file == NULL) {
+          return FAILED;
+        }
+      }
+      else
+        return FAILED;
+      count++;
       continue;
     }
     else if (!strcmp(flags[count], "-q")) {


### PR DESCRIPTION
Added option -MF so that dependency rules can be output directly to a file. This also frees the stdout for other purposes. The option is only meaningful when using -M.