### PR TITLE
Remove all tmpfile calls on Windows due to poor legacy behavior. Fixe…

### DIFF
--- a/include.c
+++ b/include.c
@@ -23,6 +23,8 @@ extern FILE *g_file_out_ptr;
 extern struct stringmaptable *g_stringmaptables;
 extern struct string *g_fopen_filenames_first;
 extern int g_is_file_isolated_counter;
+
+extern int create_tmp_file(FILE **);
         
 struct incbin_file_data *g_incbin_file_data_first = NULL, *g_ifd_tmp;
 struct active_file_info *g_active_file_info_first = NULL, *g_active_file_info_last = NULL, *g_active_file_info_tmp = NULL;
@@ -137,7 +139,7 @@ static int _find_file(char *name, FILE **f) {
   /* if we can't find the file, but are only printing makefile rules, silently use an empty file */
   /* a warning might be nice */
   if (g_makefile_rules == YES) {
-    (*f) = tmpfile();
+    create_tmp_file(f);
     if (*f != NULL)
       return SUCCEEDED;
 

--- a/phase_1.c
+++ b/phase_1.c
@@ -146,6 +146,8 @@ extern struct file_name_info *g_file_name_info_first, *g_file_name_info_last, *g
 extern struct incbin_file_data *g_incbin_file_data_first, *g_ifd_tmp;
 extern int g_makefile_rules, g_parsing_function_body, g_force_add_namespace, g_is_file_isolated_counter, g_force_ignore_namespace;
 
+extern int create_tmp_file(FILE **);
+
 static int s_macro_stack_size = 0, s_repeat_stack_size = 0;
 static int s_bank = 0, s_bank_defined = 1, s_line_count_status = ON;
 static int s_block_status = 0, s_block_name_id = 0, s_parse_dstruct_result;
@@ -5869,7 +5871,7 @@ int directive_fopen(void) {
   if (f->f == NULL) {
     if (g_makefile_rules == YES) {
       /* lets just use a tmp file for file operations */
-      f->f = tmpfile();
+      create_tmp_file(&f->f);
       if (f->f == NULL) {
         print_error(ERROR_DIR, "Error creating a tmp file for \"%s\"!\n", f->filename);
         return FAILED;


### PR DESCRIPTION
Fixes #593.

Use `extern int create_tmp_file(FILE **);` to avoid the need for a new source file for now. We may wish to split it out in the future.