### PR TITLE
Fix obsolete empty parens, caused error compiling on mac

### DIFF
--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -4603,7 +4603,7 @@ static int _labels_sort(const void *a, const void *b) {
 }
 
 
-int sort_anonymous_labels() {
+int sort_anonymous_labels(void) {
 
   int j = 0;
   struct label *l;


### PR DESCRIPTION
Fix obsolete empty parens, caused error compiling with homebrew toolchain

Error was "A function declaration without a prototype is deprecated in all versions of C"

More info here: https://stackoverflow.com/questions/75943541/a-function-declaration-without-a-prototype-is-deprecated-in-all-versions-of-c