### PR TITLE
Support for a symbol file format used by openMSX

### DIFF
--- a/wlalink/defines.h
+++ b/wlalink/defines.h
@@ -65,9 +65,10 @@
 #define STATE_SECTION_WRITE_ORDER    8
 #define STATE_RAMSECTION_WRITE_ORDER 9
 
-#define SYMBOL_MODE_NONE   0
-#define SYMBOL_MODE_NOCA5H 1
-#define SYMBOL_MODE_WLA    2
+#define SYMBOL_MODE_NONE    0
+#define SYMBOL_MODE_NOCA5H  1
+#define SYMBOL_MODE_WLA     2
+#define SYMBOL_MODE_EQU     3
 
 struct source_file_name {
   char *name;

--- a/wlalink/main.c
+++ b/wlalink/main.c
@@ -1080,6 +1080,8 @@ static int _parse_flags(char **flags, int flagc) {
       s_symbol_mode = SYMBOL_MODE_NOCA5H;
     else if (!strcmp(flags[count], "-S"))
       s_symbol_mode = SYMBOL_MODE_WLA;
+    else if (!strcmp(flags[count], "-sE"))
+      s_symbol_mode = SYMBOL_MODE_EQU;
     else if (!strcmp(flags[count], "-A"))
       s_output_addr_to_line = ON;
     else if (!strcmp(flags[count], "-d"))
@@ -1201,6 +1203,7 @@ int main(int argc, char *argv[]) {
     print_text(YES, "-r  ROM file output (default)\n");
     print_text(YES, "-R  Make file paths in link file relative to its location\n");
     print_text(YES, "-s  Write also a NO$GMB/NO$SNES symbol file\n");
+    print_text(YES, "-sE Write also an EQU symbol file\n");
     print_text(YES, "-S  Write also a WLA symbol file\n");
     print_text(YES, "-SX <WIDTH> The number of characters per line in console (default %d)\n", DEFAULT_SCREEN_DX);
     print_text(YES, "-SY <HEIGHT> The number of lines in console (default %d)\n", DEFAULT_SCREEN_DY);

--- a/wlalink/write.c
+++ b/wlalink/write.c
@@ -2336,9 +2336,9 @@ int write_symbol_file(char *outname, int mode, int output_addr_to_line) {
     return FAILED;
   }
 
-  fprintf(f, "; this file was created with wlalink by ville helin <ville.helin@iki.fi>.\n");
-
   if (mode == SYMBOL_MODE_NOCA5H) {
+    fprintf(f, "; this file was created with wlalink by ville helin <ville.helin@iki.fi>.\n");
+
     /* NOCA$H SYMBOL FILE */
     if (g_snes_mode == 0)
       fprintf(f, "; no$gmb symbolic information for \"%s\".\n", outname);
@@ -2374,8 +2374,29 @@ int write_symbol_file(char *outname, int mode, int output_addr_to_line) {
       l = l->next;
     }
   }
+  else if (mode == SYMBOL_MODE_EQU) {
+    /* EQU SYMBOL FILE */
+    l = g_labels_first;
+    while (l != NULL) {
+      if (l->alive == NO || is_label_anonymous(l->name) == YES || l->status == LABEL_STATUS_SYMBOL || l->status == LABEL_STATUS_BREAKPOINT || l->status == LABEL_STATUS_DEFINE || l->status == LABEL_STATUS_STACK) {
+        l = l->next;
+        continue;
+      }
+      /* skip all dropped section labels */
+      if (l->section_status == ON) {
+        s = find_section(l->section);
+        if (s->alive == NO) {
+          l = l->next;
+          continue;
+        }
+      }
+      fprintf(f, "%s: equ %.4xH\n", l->name, (int)l->address);
+      l = l->next;
+    }
+  }
   else {
     /* WLA SYMBOL FILE */
+    fprintf(f, "; this file was created with wlalink by ville helin <ville.helin@iki.fi>.\n");
     fprintf(f, "; wla symbolic information for \"%s\".\n", outname);
 
     /* info section */


### PR DESCRIPTION
The openMSX emulator debugger cannot read the NOCASH and WLA symbol file formats. Instead it uses a simple format using `equ` expressions.
For example, assuming a label `my_label` at address `$1234`, the corresponding entry in the symbol file would be `my_label: equ 1234H`.
In this PR, I added a new option to `wlalink`, `-sE`, to export a symbol file in the `equ` format. 
