### PR TITLE
Fixed the -MF option

### DIFF
--- a/include.c
+++ b/include.c
@@ -16,7 +16,7 @@
 #include "main.h"
 
 
-extern int g_source_index, g_extra_definitions, g_parsed_int, g_use_incdir, g_makefile_rules, g_makefile_add_phony_targets;
+extern int g_source_index, g_extra_definitions, g_parsed_int, g_use_incdir, g_makefile_rules, g_makefile_add_phony_targets, g_makefile_skip_file_handling;
 extern FILE* g_makefile_rule_file;
 extern char *g_tmp, g_label[MAX_NAME_LENGTH + 1];
 extern struct ext_include_collection g_ext_incdirs;
@@ -139,7 +139,7 @@ int find_file(char *name, FILE **f) {
 
   /* if we can't find the file, but are only printing makefile rules, silently use an empty file */
   /* a warning might be nice */
-  if (g_makefile_rules == YES) {
+  if (g_makefile_skip_file_handling == YES) {
     create_tmp_file(f);
     if (*f == NULL) {
       print_error(ERROR_INC, "Error creating a tmp file for \"%s\"!\n", name);
@@ -419,7 +419,7 @@ int incbin_file(char *name, int *id, int *swap, int *skip, int *read, struct mac
 
       *skip = g_parsed_int;
 
-      if (g_parsed_int >= file_size && g_makefile_rules == NO) {
+      if (g_parsed_int >= file_size && g_makefile_skip_file_handling == NO) {
         print_error(ERROR_INB, "SKIP value (%d) is more than the size (%d) of file \"%s\".\n", g_parsed_int, file_size, g_full_name);
         return FAILED;
       }
@@ -505,7 +505,7 @@ int incbin_file(char *name, int *id, int *swap, int *skip, int *read, struct mac
       break;
   }
 
-  if (g_makefile_rules == YES) {
+  if (g_makefile_skip_file_handling == YES) {
     /* if in test mode, fake the data to be enough to read */
     if (*read < 0)
       file_size = *skip - *read;

--- a/main.c
+++ b/main.c
@@ -70,7 +70,7 @@ extern int g_include_in_tmp_size, g_tmp_a_size, *g_banks, *g_bankaddress, g_dsp_
 extern int g_saved_structures_count, g_sizeof_g_tmp, g_global_listfile_items, *g_global_listfile_ints;
 
 int g_output_format = OUTPUT_NONE, g_verbose_level = 0, g_test_mode = OFF;
-int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO, g_makefile_add_phony_targets = NO;
+int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO, g_makefile_add_phony_targets = NO, g_makefile_skip_file_handling = NO;
 FILE *g_makefile_rule_file = NULL;
 int g_listfile_data = NO, g_quiet = NO, g_use_incdir = NO, g_little_endian = YES;
 int g_create_sizeof_definitions = YES, g_global_label_hint = HINT_NONE, g_keep_empty_sections = NO;
@@ -566,6 +566,7 @@ static int _parse_flags(char **flags, int flagc, int *print_usage) {
     g_test_mode = ON;
     g_verbose_level = 0;
     g_quiet = YES;
+    g_makefile_skip_file_handling = YES;
   }
 
   /* make sure test mode is still turned on! */

--- a/phase_1.c
+++ b/phase_1.c
@@ -146,7 +146,7 @@ extern char *g_final_name;
 extern struct active_file_info *g_active_file_info_first, *g_active_file_info_last, *g_active_file_info_tmp;
 extern struct file_name_info *g_file_name_info_first, *g_file_name_info_last, *g_file_name_info_tmp;
 extern struct incbin_file_data *g_incbin_file_data_first, *g_ifd_tmp;
-extern int g_makefile_rules, g_parsing_function_body, g_force_add_namespace, g_is_file_isolated_counter, g_force_ignore_namespace;
+extern int g_makefile_rules, g_makefile_skip_file_handling, g_parsing_function_body, g_force_add_namespace, g_is_file_isolated_counter, g_force_ignore_namespace;
 
 extern int create_tmp_file(FILE **);
 
@@ -5869,7 +5869,7 @@ int directive_fopen(void) {
   /* open the file */
   o = find_file(f->filename, &(f->f));
   if (f->f == NULL) {
-    if (g_makefile_rules == YES) {
+    if (g_makefile_skip_file_handling == YES) {
       /* lets just use a tmp file for file operations */
       create_tmp_file(&f->f);
       if (f->f == NULL) {
@@ -10398,7 +10398,7 @@ int directive_stringmaptable(void) {
 
   table_file = fopen(map->filename, "r");
   if (table_file == NULL) {
-    if (g_makefile_rules == YES) {
+    if (g_makefile_skip_file_handling == YES) {
       /* if in makefile mode, this is not an error, we just make an empty map */
       return SUCCEEDED;
     }
@@ -10555,7 +10555,7 @@ int directive_stringmap(void) {
     }
     /* if no match was found, it's an error */
     if (entry == NULL) {
-      if (g_makefile_rules == YES) {
+      if (g_makefile_skip_file_handling == YES) {
         /* in makefile mode, it's ignored */
         return SUCCEEDED;
       }


### PR DESCRIPTION
When generating makefile rules, some file handling routines are skipped  or faked.
That's not the desirable behavior when using the -MF option, as it redirects the makefile rules generation to a different file, and the expection is that the build itself remains unchanged.
This PR fixes the -MF option behavior.