### PR TITLE
When an error occurs we print the whole call stack instead of just th…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 1... WLA GB-Z80/Z80/Z80N/6502/65C02/65CE02/65816/68000/6800/6801/6809/8008/8080/HUC6280/SPC-700/SuperFX History
 ---------------------------------------------------------------------------------------------------------------
 
-v10.7 (18-Feb-2026) [ALL] Prefixed by a hashtag didn't propagate though nested .MACRO
+v10.7 (22-Feb-2026) [ALL] Prefixed by a hashtag didn't propagate though nested .MACRO
                       calls.
                     [ALL] Listfile creation for library files should now work.
                     [ALL] If an object file contained only .SECTIONs in ROM
@@ -34,6 +34,8 @@ v10.7 (18-Feb-2026) [ALL] Prefixed by a hashtag didn't propagate though nested .
                     [ALL] Fixed an issue with -h flag and defines in some
                       instructions being interpreted early as labels.
                     [ALL] Fix to .MACRO parsing when using ARGS.
+                    [ALL] When an error occurs we print the whole call stack instead
+                      of just the file name and line number where it happened.
                     [658] Fixed BRL and PER to work properly.
                     [68k] Added alias SP for register a7.
                     [68k] BCLR, BSET and BTST used wrong range [1, 8] / [1, 32] for

--- a/defines.h
+++ b/defines.h
@@ -571,6 +571,14 @@ struct definition {
   int    size;
 };
 
+struct call_stack_item {
+  char filename[MAX_NAME_LENGTH + 1];
+  char macro_name[MAX_NAME_LENGTH + 1];
+  int line_number;  
+  struct call_stack_item *next;
+  struct call_stack_item *prev;
+};
+
 struct after_section {
   char  alive;
   char  is_appendto;

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ FILE *g_file_out_ptr = NULL;
 __near long __stack = 200000;
 #endif
 
-char s_version_string[] = "$VER: wla-" WLA_NAME " 10.7a (18.2.2026)";
+char s_version_string[] = "$VER: wla-" WLA_NAME " 10.7a (22.2.2026)";
 char s_wla_version[] = "10.7";
 
 extern struct incbin_file_data *g_incbin_file_data_first, *g_ifd_tmp;
@@ -61,6 +61,9 @@ extern struct structure **g_saved_structures;
 extern struct string *g_fopen_filenames_first, *g_fopen_filenames_last;
 extern struct function *g_functions_first, *g_functions_last;
 extern struct namespace *g_namespaces_first;
+extern struct call_stack_item *g_call_stack_items_first, *g_call_stack_items_last;
+extern struct active_file_info *g_active_file_info_first, *g_active_file_info_last, *g_active_file_info_tmp;
+extern struct macro_runtime *g_macro_stack, *g_macro_runtime_current;
 extern char g_mem_insert_action[MAX_NAME_LENGTH*3 + 1024], g_latest_include_dir[MAX_NAME_LENGTH + 1];
 extern char *g_label_stack[256], *g_tmp, *g_global_listfile_cmds, g_latest_label[MAX_NAME_LENGTH + 1];
 extern char *g_include_in_tmp, *g_tmp_a;
@@ -74,7 +77,7 @@ int g_extra_definitions = OFF, g_commandline_parsing = ON, g_makefile_rules = NO
 FILE *g_makefile_rule_file = NULL;
 int g_listfile_data = NO, g_quiet = NO, g_use_incdir = NO, g_little_endian = YES;
 int g_create_sizeof_definitions = YES, g_global_label_hint = HINT_NONE, g_keep_empty_sections = NO;
-int g_can_calculate_a_minus_b = YES, g_is_file_isolated_counter = 0;
+int g_can_calculate_a_minus_b = YES, g_is_file_isolated_counter = 0, g_print_call_stack_on_exit = NO;
 int g_continue_parsing_after_an_error = NO, g_continued_parsing_after_an_error = NO;
 int g_allow_labels_without_colon = YES, g_is_data_stream_parser_enabled = YES;
 
@@ -645,6 +648,31 @@ static void _procedures_at_exit(void) {
   struct array *ar1, *ar2;
   struct string *strings;
   int i, index;
+
+  /* delayed printing of call stack as errors might output multiple lines of text
+     from different places in code */
+  if (g_print_call_stack_on_exit == YES) {
+    if (g_active_file_info_last != NULL) {
+      struct call_stack_item *csi = g_call_stack_items_last;
+
+      /* print the file + line number */
+      print_text(NO, "  at %s:%d", get_file_name(g_active_file_info_last->filename_id), g_active_file_info_last->line_current);
+      if (g_macro_runtime_current != NULL)
+        print_text(NO, ":%s()\n", g_macro_runtime_current->macro->name);
+      else
+        print_text(NO, "\n");
+
+      /* print call stack */
+      while (csi != NULL) {
+        print_text(NO, "  <- %s:%d", csi->filename, csi->line_number);
+        if (csi->macro_name[0] != 0)
+          print_text(NO, ":%s()\n", csi->macro_name);
+        else
+          print_text(NO, "\n");
+        csi = csi->prev;
+      }
+    }
+  }
   
   /* free all the dynamically allocated data structures and close open files */
   if (g_file_out_ptr != NULL) {
@@ -755,6 +783,14 @@ static void _procedures_at_exit(void) {
     m = g_macros_first;
   }
 
+  while (g_call_stack_items_first != NULL) {
+    struct call_stack_item *csi;
+
+    csi = g_call_stack_items_first->next;
+    free(g_call_stack_items_first);
+    g_call_stack_items_first = csi;
+  }
+  
   g_label_tmp = g_labels;
   while (g_label_tmp != NULL) {
     g_labels = g_label_tmp->next;

--- a/phase_1.c
+++ b/phase_1.c
@@ -111,6 +111,7 @@ char g_current_directive[MAX_NAME_LENGTH + 1];
 
 unsigned char *g_rom_banks = NULL, *g_rom_banks_usage_table = NULL;
 
+struct call_stack_item *g_call_stack_items_first = NULL, *g_call_stack_items_last = NULL;
 struct structure **g_saved_structures = NULL;
 struct export_def *g_export_first = NULL, *g_export_last = NULL;
 struct map_t *g_defines_map = NULL;
@@ -135,7 +136,7 @@ extern char *g_buffer, *unfolded_buffer, g_label[MAX_NAME_LENGTH + 1], *g_includ
 extern int g_source_file_size, g_input_number_error_msg, g_verbose_level, g_output_format, g_open_files, g_input_parse_if;
 extern int g_last_stack_id, g_latest_stack, g_ss, g_commandline_parsing, g_newline_beginning, g_expect_calculations, g_input_parse_special_chars;
 extern int g_extra_definitions, g_string_size, g_input_float_mode, g_operand_hint, g_operand_hint_type, g_dsp_enable_label_address_conversion;
-extern int g_include_dir_size, g_parse_floats, g_listfile_data, g_quiet, g_parsed_double_decimal_numbers;
+extern int g_include_dir_size, g_parse_floats, g_listfile_data, g_quiet, g_parsed_double_decimal_numbers, g_print_call_stack_on_exit;
 extern int g_create_sizeof_definitions, g_input_allow_leading_hashtag, g_input_has_leading_hashtag, g_input_allow_leading_ampersand;
 extern int g_plus_and_minus_ends_label, g_get_next_token_use_substitution, g_input_number_turn_values_into_strings;
 extern int g_continue_parsing_after_an_error, g_continued_parsing_after_an_error, g_allow_labels_without_colon;
@@ -333,6 +334,64 @@ static int _get_slot_number_by_a_value(int value, int *slot) {
 }
 
 
+static int _call_stack_item_push(void) {
+
+  struct call_stack_item *csi;
+
+  /* the 1st file in project? */
+  if (g_active_file_info_last == NULL)
+    return SUCCEEDED;
+
+  csi = calloc(1, sizeof(struct call_stack_item));
+  if (csi == NULL) {
+    print_error(ERROR_ERR, "Out of memory error while allocating a call stack item.\n");
+    return FAILED;
+  }
+
+  csi->line_number = g_active_file_info_last->line_current;
+  strcpy(csi->filename, get_file_name(g_active_file_info_last->filename_id));
+  csi->next = NULL;
+  csi->prev = g_call_stack_items_last;
+
+  if (g_macro_runtime_current != NULL && g_macro_runtime_current->macro != NULL)
+    strcpy(csi->macro_name, g_macro_runtime_current->macro->name);
+  else
+    csi->macro_name[0] = 0;
+
+  if (g_call_stack_items_first == NULL)
+    g_call_stack_items_first = csi;
+
+  if (g_call_stack_items_last != NULL)
+    g_call_stack_items_last->next = csi;
+  g_call_stack_items_last = csi;
+
+  return SUCCEEDED;
+}
+
+
+static int _call_stack_item_pop(void) {
+
+  struct call_stack_item *csi;
+  
+  csi = g_call_stack_items_last;
+  if (csi == NULL) {
+    print_error(ERROR_ERR, "Calling _call_stack_item_pop(), but the call stack is empty! Please submit a bug report!\n");
+    return FAILED;
+  }
+
+  if (csi->prev != NULL)
+    csi->prev->next = NULL;
+  else
+    g_call_stack_items_first = NULL;
+
+  g_call_stack_items_last = csi->prev;
+
+  free(csi);
+
+  return SUCCEEDED;
+}
+
+
 int macro_get(char *name, int add_namespace, struct macro_static **macro_out) {
 
   struct macro_static *macro;
@@ -404,7 +463,8 @@ static int _macro_stack_grow(void) {
     }
 
     g_macro_stack = macro;
-    g_macro_runtime_current = &g_macro_stack[g_macro_active - 1];
+    if (g_macro_active > 0)
+      g_macro_runtime_current = &g_macro_stack[g_macro_active - 1];
   }
 
   return SUCCEEDED;
@@ -412,6 +472,9 @@ static int _macro_stack_grow(void) {
 
 
 static int _macro_start(struct macro_static *m, struct macro_runtime *mrt, int caller, int nargs) {
+
+  if (_call_stack_item_push() == FAILED)
+    return FAILED;
 
   g_macro_runtime_current = mrt;
   g_macro_active++;
@@ -1557,9 +1620,7 @@ void print_error(int type, char *error, ...) {
     break;
   }
 
-  if (g_active_file_info_last != NULL)
-    print_text(NO, "%s:%d: ", get_file_name(g_active_file_info_last->filename_id), g_active_file_info_last->line_current);
-
+  /* print the error */
   if (t != NULL) {
     print_text(NO, t);
     print_text(NO, " ");
@@ -1569,6 +1630,8 @@ void print_error(int type, char *error, ...) {
   print_text_using_args(NO, error, args);
   va_end(args);
 
+  g_print_call_stack_on_exit = YES;
+  
   fflush(stderr);
 
   return;
@@ -9516,6 +9579,9 @@ int directive_endm(void) {
   int q;
   
   if (g_macro_active != 0) {
+    if (_call_stack_item_pop() == FAILED)
+      return FAILED;
+
     g_macro_active--;
 
     /* macro call end */
@@ -11151,6 +11217,9 @@ int directive_changefile(void) {
 
   int q;
   
+  if (_call_stack_item_push() == FAILED)
+    return FAILED;
+
   q = input_number();
   if (q != SUCCEEDED) {
     print_error(ERROR_DIR, "Internal error in (internal) .CHANGEFILE. Please submit a bug report...\n");
@@ -11814,7 +11883,10 @@ int parse_directive(void) {
           g_is_file_isolated_counter--;
         if (g_is_file_isolated_counter == 1)
           g_is_file_isolated_counter = 0;
-          
+
+        if (_call_stack_item_pop() == FAILED)
+          return FAILED;
+        
         return SUCCEEDED;
       }
     }

--- a/tests/8080/linker_test/include1.s
+++ b/tests/8080/linker_test/include1.s
@@ -1,6 +1,6 @@
 
-	.print "INCLUDE:::IN\n"
+	.print "INCLUDE:::IN - include1.s\n"
 	.db 0, 1, 2, 3, 4, 5
 	.db 6, 7, 8, 9, 10, \1
-	.print "INCLUDE:::OUT\n"
+	.print "INCLUDE:::OUT - include1.s\n"
 

--- a/tests/8080/linker_test/main.s
+++ b/tests/8080/linker_test/main.s
@@ -89,16 +89,16 @@ DummyMain:
 .ENDS
 
 .MACRO JUMP_MACRO
-	.print "OUTMOST:::IN\n"
+	.print "OUTMOST:::IN - JUMP_MACRO\n"
         MACRO_INCLUDE_1 11 \1
-	.print "OUTMOST:::OUT\n"
+	.print "OUTMOST:::OUT - JUMP_MACRO\n"
 .ENDM
 
 .MACRO MACRO_INCLUDE_1
-	.print "INSIDE:::IN\n"
+	.print "INSIDE:::IN - MACRO_INCLUDE_1\n"
 	.include include1.s
 	.db \2
-	.print "INSIDE:::OUT\n"
+	.print "INSIDE:::OUT - MACRO_INCLUDE_1\n"
 .ENDM
 
 .MACRO MACRO_INCLUDE_2


### PR DESCRIPTION
…e file name and line number where it happened. Should fix GitHub issue #690.