### PR TITLE
Fix WLAVALRGIND typo so wlalink runs under Valgrind in these tests

### DIFF
--- a/tests/gb-z80/ai_generated_tests/makefile
+++ b/tests/gb-z80/ai_generated_tests/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/continue_test/makefile
+++ b/tests/gb-z80/continue_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/delta_test/makefile
+++ b/tests/gb-z80/delta_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/duplicate_labels/makefile
+++ b/tests/gb-z80/duplicate_labels/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -C -s
 
 SFILES = bank0.s bank1.s

--- a/tests/gb-z80/gbheader_test/makefile
+++ b/tests/gb-z80/gbheader_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/instructions_test/makefile
+++ b/tests/gb-z80/instructions_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/labels_test/makefile
+++ b/tests/gb-z80/labels_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/listfile_test/makefile
+++ b/tests/gb-z80/listfile_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/gb-z80/macro_parser_test/makefile
+++ b/tests/gb-z80/macro_parser_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-gb
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s

--- a/tests/z80n/instructions_test/makefile
+++ b/tests/z80n/instructions_test/makefile
@@ -1,7 +1,7 @@
 
 CC = $(WLAVALGRIND) wla-z80n
 CFLAGS = -i -x -o
-LD = $(WLAVALRGIND) wlalink
+LD = $(WLAVALGRIND) wlalink
 LDFLAGS = -i -v -s
 
 SFILES = main.s


### PR DESCRIPTION
Ten test makefiles set `LD = $(WLAVALRGIND) wlalink`, but the variable is spelled `WLAVALGRIND` everywhere else, and `run_tests.sh` only ever exports `WLAVALGRIND`. The misspelled `$(WLAVALRGIND)` expanded to nothing, so `wlalink` ran **without** Valgrind in these ten tests — even though the assembler on the `CC` line right above it did not. The result was that linker memory checking was silently skipped here. This corrects the spelling in all ten makefiles; there is no source or behaviour change.

**Affected makefiles**

- `tests/gb-z80/`: `ai_generated_tests`, `continue_test`, `delta_test`, `duplicate_labels`, `gbheader_test`, `instructions_test`, `labels_test`, `listfile_test`, `macro_parser_test`
- `tests/z80n/instructions_test`

**Verification (Valgrind 3.25.1)** — ran all ten under the suite's strict config (`--leak-check=full --errors-for-leak-kinds=all --error-exitcode=1`). All ten pass, and `wlalink` now actually runs under Valgrind. For example in `duplicate_labels`:

```
==…== Command: wlalink -i -v -C -s linkfile linked.gb
==…== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Zero errors and no leaks. Before this fix that `wlalink` Valgrind run never happened, so the linker's memory was never checked in these tests.
