### PR TITLE
Fix MC68000 labels and definitions named S0..S7 parsing as register A7

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -972,7 +972,7 @@ static int _mc68000_parse_ea(char *code, int *index, int *reg1, int *reg2, int *
       return FAILED;
     
     i++;
-    if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+    if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
       if (c == 'S')
         *reg1 = 7;
       else
@@ -1034,7 +1034,7 @@ static int _mc68000_parse_ea(char *code, int *index, int *reg1, int *reg2, int *
     /* An? */
     if (c == 'A' || c =='S') {
       i++;
-      if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+      if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
         if (c == 'S')
           *reg1 = 7;
         else
@@ -1103,7 +1103,7 @@ static int _mc68000_parse_ea(char *code, int *index, int *reg1, int *reg2, int *
           return FAILED;
 
         i++;
-        if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+        if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
           if (c == 'S')
             *reg1 = 7;
           else
@@ -1295,7 +1295,7 @@ static int _mc68000_parse_ea(char *code, int *index, int *reg1, int *reg2, int *
     else if (c == 'A' || c == 'S') {
       /* d16(An) */
       i++;
-      if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+      if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
         *mode = B8(00000101);
 
         if (c == 'S')
@@ -1349,7 +1349,7 @@ static int _mc68000_parse_register(char *code, int *index, int *reg, int *mode) 
       return FAILED;
     
     i++;
-    if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+    if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
       if (c == 'S')
         *reg = 7;
       else
@@ -1372,7 +1372,7 @@ static int _mc68000_parse_register(char *code, int *index, int *reg, int *mode) 
 
     if (c == 'A' || c == 'S') {
       i++;
-      if ((code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
+      if ((c != 'S' && code[i] >= '0' && code[i] <= '7') || (c == 'S' && toupper((int)code[i]) == 'P')) {
         if (c == 'S')
           *reg = 7;
         else

--- a/tests/68000/sp_alias_test/linkfile
+++ b/tests/68000/sp_alias_test/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/tests/68000/sp_alias_test/main.s
+++ b/tests/68000/sp_alias_test/main.s
@@ -26,8 +26,8 @@
 .ORG 0
 
         .db "AB>"               ; @BT TEST-01 AB START
-S3:     move.w S3,d0            ; @BT 30 39 00 00 00 03
-        move.w S6,d1            ; @BT 32 39 00 00 00 10
-        move.w sp,d2            ; @BT 34 0F
-        move.w a7,d3            ; @BT 36 0F
+S3:     move.w S3,d0            ; @BT $30 $39 $00 $00 $00 $03
+        move.w S6,d1            ; @BT $32 $39 $00 $00 $00 $10
+        move.w sp,d2            ; @BT $34 $0F
+        move.w a7,d3            ; @BT $36 $0F
         .db "<AB"               ; @BT END

--- a/tests/68000/sp_alias_test/main.s
+++ b/tests/68000/sp_alias_test/main.s
@@ -1,0 +1,33 @@
+; NOTE: This test was created by Claude Fable 5.
+; @BT linked.rom
+
+; Regression test for the MC68000 "SP" register alias.
+;
+; A label or definition named S0..S7 must NOT be parsed as address register
+; A7 -- the SP alias must only match the exact token "SP". With the bug, the
+; operand parser accepted "S" followed by a digit as An, so "move.w S3,d0"
+; assembled as "move.w a7,d0" (30 0f) instead of an absolute reference to the
+; label S3. SP / A7 themselves must still assemble to the A7 form.
+
+.MEMORYMAP
+  DEFAULTSLOT 0
+  SLOT 0 $000000 $100000
+.ENDME
+
+.ROMBANKMAP
+  BANKSTOTAL 1
+  BANKSIZE $100000
+  BANKS 1
+.ENDRO
+
+.define S6 $0010
+
+.BANK 0 SLOT 0
+.ORG 0
+
+        .db "AB>"               ; @BT TEST-01 AB START
+S3:     move.w S3,d0            ; @BT 30 39 00 00 00 03
+        move.w S6,d1            ; @BT 32 39 00 00 00 10
+        move.w sp,d2            ; @BT 34 0F
+        move.w a7,d3            ; @BT 36 0F
+        .db "<AB"               ; @BT END

--- a/tests/68000/sp_alias_test/makefile
+++ b/tests/68000/sp_alias_test/makefile
@@ -1,0 +1,24 @@
+
+CC = $(WLAVALGRIND) wla-68000
+CFLAGS = -i -o
+LD = $(WLAVALGRIND) wlalink
+LDFLAGS = -i -v -s
+
+SFILES = main.s
+OFILES = main.o
+
+all: linked.rom check
+
+linked.rom: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile linked.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+check: linked.rom
+	byte_tester -s main.s
+
+$(OFILES): $(HFILES)
+
+clean:
+	rm -f $(OFILES) core *~ linked.rom *.sym *.lst


### PR DESCRIPTION
The new `SP` alias for address register A7 widened the operand parser's register condition to accept a leading `S`, but the digit branch was not gated to A/D. So a token like `S3` satisfied the `'0'..'7'` digit test and was then forced to A7 — meaning any label or definition named `S0`..`S7` used as an operand silently assembled as A7. For example:

```
move.w S3,d0   ->  30 0f      (i.e. move.w a7,d0)
```

instead of an absolute reference to `S3`.

Gate the digit branch with `c != 'S'` at all six MC68000 register-parse sites, so only the exact token `SP` maps to A7; `S3` now falls through to normal label/number parsing.

Adds `tests/68000/sp_alias_test`, asserting that a label `S3` and a definition `S6` resolve to their address/value while `SP` and `A7` still emit the A7 form.
