### PR TITLE
Fix mid() integer overflow that could crash the assembler

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -1475,7 +1475,7 @@ static int _parse_function_left_mid_right(char *in, struct stack_item *si, int *
     print_error(ERROR_NUM, "%s() start index %d is outside string \"%s\"!\n", name, start, tmp);
     return FAILED;
   }
-  if (start + length > string_length) {
+  if (length > string_length - start) {
     print_error(ERROR_NUM, "%s() length %d runs outside string \"%s\"!\n", name, length, tmp);
     return FAILED;
   }

--- a/tests/6502/functions_error_test/makefile
+++ b/tests/6502/functions_error_test/makefile
@@ -1,0 +1,20 @@
+CC = $(WLAVALGRIND) wla-6502
+CFLAGS = -o
+
+ERROR_SFILES = mid_overflow.s
+
+all: check
+
+check:
+	@set -e; \
+	command -v wla-6502 >/dev/null 2>&1; \
+	for source in $(ERROR_SFILES); do \
+		if $(CC) $(CFLAGS) failed.o $$source > $$source.log 2>&1; then \
+			echo "$$source unexpectedly assembled"; \
+			exit 1; \
+		fi; \
+	done; \
+	grep -F "mid() length 2147483647 runs outside string" mid_overflow.s.log >/dev/null
+
+clean:
+	rm -f *.o *.log core *~

--- a/tests/6502/functions_error_test/mid_overflow.s
+++ b/tests/6502/functions_error_test/mid_overflow.s
@@ -1,0 +1,20 @@
+; NOTE: This test was created by Claude Fable 5.
+.memorymap
+defaultslot 0
+slot 0 $0000 $2000
+.endme
+
+.rombankmap
+bankstotal 1
+banksize $2000
+banks 1
+.endro
+
+.bank 0 slot 0
+.org 0
+
+; mid()'s "runs outside string" check used to compute start + length, which
+; overflowed to a negative value for huge lengths and let the bounds check
+; pass -- the copy loop then wrote ~2 GB and crashed. The assembler must now
+; reject this with a clean error instead of segfaulting.
+.db mid(1, 2147483647, "abc")


### PR DESCRIPTION
`mid()`'s out-of-range check computed `start + length > string_length`. For a large length — e.g. `mid(1, 2147483647, "abc")` — `start + length` overflowed to a negative value, the check passed, and the following copy loop wrote ~2 GB into the 256-byte stack item. A segfault driven purely by assembler source input.

Compare as `length > string_length - start` instead. At that point `0 <= start <= string_length` and `length >= 0` are already guaranteed, so `string_length - start` is a non-negative in-range value and the subtraction cannot overflow. `left()`/`right()` share the same check.

Adds `tests/6502/functions_error_test`, asserting the oversized `mid()` is rejected with a clean error. The test greps the log for the range message, which a crash would never print — so it genuinely fails against the unpatched (crashing) binary.
