### PR TITLE
Fix section-relative labels passed to .MACRO resolving to section start

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -4059,7 +4059,7 @@ static int _resolve_string(struct stack_item *s, int *cannot_resolve) {
               return FAILED;
             
             s->type = STACK_ITEM_TYPE_VALUE;
-            s->value = g_slots[section->slot].address + section->address;
+            s->value = g_slots[section->slot].address + dSI->address;
           }
           else {
             /* wla cannot resolve freely floating address labels -> only wlalink can do that */

--- a/tests/65816/macro_section_label_test/linkfile
+++ b/tests/65816/macro_section_label_test/linkfile
@@ -1,0 +1,2 @@
+[objects]
+main.o

--- a/tests/65816/macro_section_label_test/main.s
+++ b/tests/65816/macro_section_label_test/main.s
@@ -1,0 +1,41 @@
+; NOTE: This test was created by Claude Fable 5.
+
+//////////////////////////////////////////////////////////////////////
+// Regression test: a label inside a FORCE/OVERWRITE .SECTION, passed to
+// a .MACRO and used in an assembly-time calculation, must resolve to the
+// label's own address -- not the section's start address.
+//
+// With the bug (stack.c _resolve_string), every such label resolved to
+// g_slots[...].address + section->address, so two labels in the same
+// FORCE section both collapsed to the section start and their difference
+// computed to 0 instead of their real distance.
+//////////////////////////////////////////////////////////////////////
+
+.memorymap
+        slotsize $8000
+        defaultslot 1
+        slot 0 $0000
+        slot 1 $8000
+.endme
+
+.lorom
+
+.rombanksize $8000
+.rombanks 1
+
+.bank 0 slot 1
+
+; @BT result.rom
+
+.MACRO EmitDiff ARGS a, b
+  .db b - a
+.ENDM
+
+.section "ForcedLabels" FORCE
+        .db "AB>"                  ; @BT TEST-01 AB START
+first:
+        .db $00 $00 $00 $00 $00    ; @BT 00 00 00 00 00
+second:
+        EmitDiff first, second     ; @BT 05
+        .db "<AB"                  ; @BT END
+.ends

--- a/tests/65816/macro_section_label_test/makefile
+++ b/tests/65816/macro_section_label_test/makefile
@@ -1,0 +1,27 @@
+
+CC = $(WLAVALGRIND) wla-65816
+CFLAGS = -v -i -o
+LD = $(WLAVALGRIND) wlalink
+LDFLAGS = -v -i -s
+
+SFILES = main.s
+IFILES = 
+OFILES = main.o
+
+all: result.rom check
+
+result.rom: $(OFILES) makefile
+	$(LD) $(LDFLAGS) linkfile result.rom
+
+main.o: main.s
+	$(CC) $(CFLAGS) main.o main.s
+
+check: result.rom
+	byte_tester -s main.s
+
+$(OFILES): $(HFILES)
+
+
+clean:
+	rm -f $(OFILES) core *~ result.rom result.sym *.lst
+


### PR DESCRIPTION
When a label defined inside a FORCE/OVERWRITE `.SECTION` is passed to a `.MACRO` and used in an assembly-time calculation, `_resolve_string` computed its value as the section's start address (`g_slots[...].address + section->address`) instead of the label's own address. Every label in the section therefore collapsed to the same value, so e.g. the difference of two such labels evaluated to 0.

**Introduced in** [`44ca5c12`](https://github.com/vhelin/wla-dx/commit/44ca5c127f8a16f060aaf2d3c14899c532bc969d) ("`.BASE`/`BASE` affects now labels when replaced with their address in `.MACRO` arguments", GitHub #649), which added both resolution branches at once — and only the in-section one used the wrong address:

```diff
+  /* a label outside .SECTIONs */
+  s->value = g_slots[dSI->slot].address + dSI->address;            // the label  (correct)
...
+  /* a label inside a FORCE/OVERWRITE .SECTION */
+  s->value = g_slots[section->slot].address + section->address;    // the section start  (bug)
```

The outside-section branch already used the label's own `dSI->address`; the FORCE/OVERWRITE branch used `section->address`. This fix makes the second match the first.

Use the label's address from the data-stream item (`dSI->address`, the absolute in-slot address) — mirroring the outside-section branch, which already uses `g_slots[dSI->slot].address + dSI->address`.

Adds `tests/65816/macro_section_label_test`, asserting that two labels at different offsets in a FORCE section, passed to a macro, yield their true distance rather than 0.
