### PR TITLE
Fix .REPT/.REPEAT hanging on an unexpected token after the count

### DIFF
--- a/phase_1.c
+++ b/phase_1.c
@@ -10919,18 +10919,18 @@ static int _directive_rept_repeat_while(int is_while) {
         continue;
       }
 
-      /* test for EOL */
-      _remember_current_source_file_position();
-
+      /* the only thing that's allowed here is the end of the line */
       q = input_number();
       if (q == INPUT_NUMBER_EOL) {
         g_parsed_int = counter;
         next_line();
         break;
       }
+      else if (q == FAILED)
+        return FAILED;
       else {
-        /* this is not yet the end */
-        _roll_back_to_remembered_source_file_position();
+        print_error(ERROR_DIR, ".%s got an unexpected token. Expected INDEX, START, STEP or the end of the line.\n", c);
+        return FAILED;
       }
     }
 

--- a/tests/z80/rept_error_test/makefile
+++ b/tests/z80/rept_error_test/makefile
@@ -1,0 +1,20 @@
+CC = $(WLAVALGRIND) wla-z80
+CFLAGS = -o
+
+ERROR_SFILES = rept_trailing.s
+
+all: check
+
+check:
+	@set -e; \
+	command -v wla-z80 >/dev/null 2>&1; \
+	for source in $(ERROR_SFILES); do \
+		if $(CC) $(CFLAGS) failed.o $$source > $$source.log 2>&1; then \
+			echo "$$source unexpectedly assembled"; \
+			exit 1; \
+		fi; \
+	done; \
+	grep -F "got an unexpected token" rept_trailing.s.log >/dev/null
+
+clean:
+	rm -f *.o *.log core *~

--- a/tests/z80/rept_error_test/rept_trailing.s
+++ b/tests/z80/rept_error_test/rept_trailing.s
@@ -1,0 +1,21 @@
+; NOTE: This test was created by Claude Fable 5.
+.memorymap
+defaultslot 0
+slot 0 $0000 $2000
+.endme
+
+.rombankmap
+bankstotal 1
+banksize $2000
+banks 1
+.endro
+
+.bank 0 slot 0
+.org 0
+
+; The .REPT/.REPEAT option parser only stopped on end-of-line, so any
+; unexpected token after the count (here "5") was rolled back and retried
+; forever -- the assembler hung. It must now report a clear error instead.
+.rept 2 5
+        nop
+.endr


### PR DESCRIPTION
The `.REPT`/`.REPEAT` `START`/`STEP` option loop only broke out on end-of-line: any other token after the count was read, rolled back, and retried on the next iteration — forever. So `.REPT 2 5` (or any stray token after the count) hung the assembler, and a parse failure printed the same error in an endless loop.

**Introduced in** [`b44d8341`](https://github.com/vhelin/wla-dx/commit/b44d8341a0cb33c5981108e6ae80a2714a9b5458) ("Added START and STEP to .REPEAT/.REPT", GitHub #670), which added the option-parsing loop. Its only exit is end-of-line; anything else is rolled back and the enclosing `while (1)` retries it indefinitely:

```diff
+      q = input_number();
+      if (q == INPUT_NUMBER_EOL) {
+        g_parsed_int = counter;
+        next_line();
+        break;
+      }
+      else {
+        /* this is not yet the end */
+        roll_back_to_remembered_source_file_position();   // → loops forever on a stray token
+      }
```

After the `INDEX`/`START`/`STEP` checks, require end-of-line: a parse failure returns `FAILED`, and anything else reports a clear "unexpected token" error and returns `FAILED`. Same-line `.REPT` bodies were already non-functional in this version (`.ENDR` continuation skips to the next line), so this only turns a non-terminating hang into a diagnostic.

Adds `tests/z80/rept_error_test`, asserting `.REPT 2 5` is rejected.
